### PR TITLE
Fix json.Unmarshal'd obligations support; also support new obligations map structure

### DIFF
--- a/grpc_opa/authorizer_test.go
+++ b/grpc_opa/authorizer_test.go
@@ -2,7 +2,10 @@ package grpc_opa_middleware
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
+	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -24,23 +27,169 @@ func Test_parseEndpoint(t *testing.T) {
 }
 
 func Test_addObligations(t *testing.T) {
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, "allow", false)
-	resp := make(OPAResponse)
-	resp["allow"] = true
+	for idx, tst := range obligationTests {
+		ctx := context.Background()
+		var resp OPAResponse
 
-	// without obligations
-	resCtx := addObligations(ctx, resp)
-	if v, ok := resCtx.Value(ObKey).([][]string); ok {
-		t.Fatalf("received obligations data: %v .. was expected to be <nil>", v)
-	}
+		err := json.Unmarshal([]byte(tst.regoRespJSON), &resp)
+		if err != nil {
+			t.Errorf("tst#%d: err=%s trying to json.Unmarshal: %s",
+				idx, err, tst.regoRespJSON)
+			continue
+		}
 
-	// with obligations
-	resp["obligations"] = [][]string{{`ctx.metric == "dhcp"`}}
-	resCtx = addObligations(ctx, resp)
-	if s, ok := resCtx.Value(ObKey).([][]string); !ok {
-		t.Fatal("obligations data missing")
-	} else if strings.Compare(`ctx.metric == "dhcp"`, s[0][0]) != 0 {
-		t.Fatal("obligations data mismatch,received:", s[0][0])
+		t.Logf("tst#%d: resp=%#v", idx, resp)
+		newCtx, actualErr := addObligations(ctx, resp)
+	        actualVal, _ := newCtx.Value(ObKey).(ObligationsType)
+
+		if actualErr != tst.expectedErr {
+			t.Errorf("tst#%d: expectedErr=%s actualErr=%s",
+				idx, tst.expectedErr, actualErr)
+		}
+
+		if actualVal != nil {
+			t.Logf("tst#%d: before sortBy1stElem: %#v", idx, actualVal)
+			actualVal.sortBy1stElem()
+		}
+		if !reflect.DeepEqual(actualVal, tst.expectedVal) {
+			// nil interface{} (untyped) does not compare equal with a nil typed value
+			// https://www.calhoun.io/when-nil-isnt-equal-to-nil/
+			// https://stackoverflow.com/questions/13476349/check-for-nil-and-nil-interface-in-go
+			if actualVal != nil || tst.expectedVal != nil {
+				t.Errorf("tst#%d: expectedVal=%#v actualVal=%#v",
+					idx, tst.expectedVal, actualVal)
+			}
+		}
 	}
+}
+
+func TestOPAResponseObligations(t *testing.T) {
+	for idx, tst := range obligationTests {
+		var resp OPAResponse
+
+		err := json.Unmarshal([]byte(tst.regoRespJSON), &resp)
+		if err != nil {
+			t.Errorf("tst#%d: err=%s trying to json.Unmarshal: %s",
+				idx, err, tst.regoRespJSON)
+			continue
+		}
+
+		t.Logf("tst#%d: resp=%#v", idx, resp)
+		actualVal, actualErr := resp.Obligations()
+
+		if actualErr != tst.expectedErr {
+			t.Errorf("tst#%d: expectedErr=%s actualErr=%s",
+				idx, tst.expectedErr, actualErr)
+		}
+
+		if actualVal != nil {
+			t.Logf("tst#%d: before sortBy1stElem: %#v", idx, actualVal)
+			actualVal.sortBy1stElem()
+		}
+		if !reflect.DeepEqual(actualVal, tst.expectedVal) {
+			t.Errorf("tst#%d: expectedVal=%#v actualVal=%#v",
+				idx, tst.expectedVal, actualVal)
+		}
+	}
+}
+
+// sortBy1stElem sorts its list of slices by their first element,
+// used for deterministic testing output
+func (ob *ObligationsType) sortBy1stElem() {
+	sort.SliceStable(*ob, func(lhs, rhs int) bool {
+		return (*ob)[lhs][0] < (*ob)[rhs][0]
+	})
+}
+
+var obligationTests = []struct {
+	expectedErr  error
+	regoRespJSON string
+	expectedVal  ObligationsType
+}{
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": "bad obligations value"
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": [ "bad obligations value" ]
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": [ [ 3.14 ] ]
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": { "policy1_guid": "bad obligations value" }
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": { "bad_obligations_value": [ 3.14 ]}
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": { "policy1_guid": { "stmt0": "bad obligations value" }}
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": [ [ "a", "b" ], [ "c" ] ]
+		}`,
+		expectedVal:  ObligationsType{
+			{ "a", "b" },
+			{ "c" },
+		},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": {
+				"policy1_guid": {
+					"stmt0": [ "a" ]
+				},
+				"policy2_guid": {
+					"stmt0": [ "b", "c" ],
+					"stmt1": [ "d" ]
+				}
+			}
+		}`,
+		expectedVal:  [][]string{
+			{ "a" },
+			{ "b", "c" },
+			{ "d" },
+		},
+	},
 }


### PR DESCRIPTION
```
$ make test
go vet ./...
go test ./...
ok      github.com/infobloxopen/atlas-authz-middleware/grpc_opa (cached)
ok      github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client   (cached)
```

```
$ pwd
/home/riccho/go/src/github.com/infobloxopen/atlas-authz-middleware/grpc_opa

$ go test
INFO[0000] authorizers empty, using default authorizer  
DEBU[0000] authorization_request                         application=myapplication request="{FakeMethod myapplication FakeService.FakeMethod eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImJvZ3VzQGZvby5jb20iLCJhcGlfdG9rZW4iOiIwMTIzNDU2Nzg5YWJjZGVmMDEyMzQ1Njc4OWFiY2RlZiIsImFjY291bnRfaWQiOiI0MDQiLCJncm91cHMiOlsiZm9vX2FkbWluIiwiYWRtaW4iXSwiYXVkIjoiZm9vLWF1ZGllbmNlIiwiZXhwIjoyMzk4MzY3NTQwLCJpYXQiOjE1MzQzNjc1NDAsImlzcyI6ImZvby1pc3N1ZXIiLCJuYmYiOjE1MzQzNjc1NDB9.redacted {electron run [map[id:guid1 name:ClassA tags:map[dept:finance zone:apj]] map[id:guid2 name:ClassB tags:map[dept:sales zone:emea]]] }}"
DEBU[0000] authorization_result                          application=myapplication elapsed="80.122µs" response="map[allow:true]"
ERRO[0000] request_json_marshal                          application=myapplication error="json: unsupported type: func([]string, []string) (string, []error)" request="{FakeMethod myapplication FakeService.FakeMethod eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzZXJ2aWNlIjoiZm9vLXNlcnZpY2UiLCJhdWQiOiJmb28tYXVkaWVuY2UiLCJleHAiOjIzOTg4NzI3NzgsImp0aSI6ImZvby1qdGkiLCJpYXQiOjE1MzUzMjE0MDcsImlzcyI6ImZvby1pc3N1ZXIiLCJuYmYiOjE1MzUzMjE0MDd9.redacted {proton jump [0x9e3c00] }}"
ERRO[0000] unable_authorize &grpc_opa_middleware.mockAuthorizerWithAllowOpaEvaluator{defAuther:(*grpc_opa_middleware.DefaultAuthorizer)(0xc00025c660)}  error="rpc error: code = InvalidArgument desc = Invalid argument"
ERRO[0000] get_decision_input                            application=myapplication error=badDecisionInputer fullMethod=FakeService.FakeMethod
ERRO[0000] unable_authorize &grpc_opa_middleware.mockAuthorizerWithAllowOpaEvaluator{defAuther:(*grpc_opa_middleware.DefaultAuthorizer)(0xc00025ca80)}  error="rpc error: code = InvalidArgument desc = Invalid argument"
PASS
ok      github.com/infobloxopen/atlas-authz-middleware/grpc_opa 0.008s
```
