### PR TITLE
Discard empty array of sub-obligations when returning obligations in middleware context

### DIFF
--- a/grpc_opa/authorizer.go
+++ b/grpc_opa/authorizer.go
@@ -361,7 +361,9 @@ func parseObligationsArray(arrIfc []interface{}) (ObligationsType, error) {
 			subResult = append(subResult, s)
 		}
 
-		result = append(result, subResult)
+		if len(subResult) > 0 {
+			result = append(result, subResult)
+		}
 	}
 
 	return result, nil
@@ -395,7 +397,9 @@ func parseObligationsMap(mapIfc map[string]interface{}) (ObligationsType, error)
 				subResult = append(subResult, s)
 			}
 
-			result = append(result, subResult)
+			if len(subResult) > 0 {
+				result = append(result, subResult)
+			}
 		}
 	}
 


### PR DESCRIPTION
```
$ make test
go vet ./...
go test ./...
ok      github.com/infobloxopen/atlas-authz-middleware/grpc_opa 0.006s
ok      github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client   (cached)
```
