### PR TITLE
Change obligations type returned in context to generic node tree with AND/OR

### DIFF
--- a/grpc_opa/obligations.go
+++ b/grpc_opa/obligations.go
@@ -1,0 +1,273 @@
+package grpc_opa_middleware
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	ErrInvalidObligations = status.Errorf(codes.Internal, "Invalid obligations")
+)
+
+type ObligationsEnum int
+const (
+	ObligationsEmpty ObligationsEnum = iota // Default "zero" value for uninitialized ObligationsEnum
+	ObligationsCondition
+	ObligationsAnd
+	ObligationsOr
+)
+
+func (o8e ObligationsEnum) String() string {
+        return []string{
+		"ObligationsEmpty",
+		"ObligationsCondition",
+		"ObligationsAnd",
+		"ObligationsOr",
+	}[o8e]
+}
+
+// ObligationsNode defines the generic obligations tree returned by middleware in the context
+type ObligationsNode struct {
+	Kind      ObligationsEnum
+	Tag       string
+	Condition string
+	Children  []*ObligationsNode
+}
+
+// String() returns a multiline pretty string representation (actually JSON),
+// intended to be human-readable for debugging purposes.
+func (o8n *ObligationsNode) String() string {
+	jsonBytes, err := json.MarshalIndent(o8n, "", "  ")
+	if err != nil {
+		return "cannot json.MarshalIndent";
+	}
+	return string(jsonBytes)
+}
+
+// ShallowLength returns the length of this node.
+// It does not include the lengths of any nested nodes.
+// Length zero means this node is empty (has no obligation).
+func (o8n *ObligationsNode) ShallowLength() int {
+	if o8n == nil {
+		return 0
+	}
+
+	switch o8n.Kind {
+	case ObligationsAnd, ObligationsOr:
+		if o8n.Children == nil {
+			return 0
+		}
+		return len(o8n.Children)
+	case ObligationsCondition:
+		return 1
+	} 
+
+	return 0
+}
+
+// ShallowLessThan returns true if lhs less than rhs.
+// Does not consider nested nodes.
+// Intended for use by DeepSort method.
+func (lhs *ObligationsNode) ShallowLessThan(rhs *ObligationsNode) bool {
+	if lhs == nil && rhs == nil {
+		return false
+	} else if lhs == nil {
+		return true
+	}
+
+	if lhs.Kind != rhs.Kind {
+		return lhs.Kind < rhs.Kind
+	}
+
+	if lhs.Tag != rhs.Tag {
+		return lhs.Tag < rhs.Tag
+	}
+
+	if lhs.Condition != rhs.Condition {
+		return lhs.Condition < rhs.Condition
+	}
+
+	if lhs.Children == nil && rhs.Children == nil {
+		return false
+	} else if lhs.Children == nil {
+		return true
+	}
+
+	if len(lhs.Children) != len(rhs.Children) {
+		return len(lhs.Children) < len(rhs.Children)
+	}
+
+	return false
+}
+
+// DeepSort recursively sorts any nested nodes.
+// Intended to be used in unit-tests to force
+// deterministic order for comparison.
+func (o8n *ObligationsNode) DeepSort() {
+	if o8n == nil || o8n.Children == nil {
+		return
+	}
+
+	for i, _ := range o8n.Children {
+		o8n.Children[i].DeepSort()
+	}
+
+	sort.SliceStable(o8n.Children, func(i, j int) bool {
+		return o8n.Children[i].ShallowLessThan(o8n.Children[j])
+	})
+
+	return
+}
+
+// parseOPAObligations parses the obligations returned from OPA
+// and returns them in standard format.
+func parseOPAObligations(opaObligations interface{}) (*ObligationsNode, error) {
+	if opaObligations == nil {
+		return nil, nil
+	}
+
+	arrIfc, isArr := opaObligations.([]interface{})
+	mapIfc, isMap := opaObligations.(map[string]interface{})
+
+	if isArr {
+		return parseObligationsArray(arrIfc)
+	} else if isMap {
+		return parseObligationsMap(mapIfc)
+	}
+
+	return nil, ErrInvalidObligations
+}
+
+// obligations json.Unmarshal()'d as type:
+// []interface {}{[]interface {}{"ctx.metric == \"dhcp\""}}
+func parseObligationsArray(arrIfc []interface{}) (*ObligationsNode, error) {
+	if IsNilInterface(arrIfc) {
+		return nil, nil
+	}
+
+	result := &ObligationsNode{
+		Kind: ObligationsEmpty,
+	}
+
+	for _, subIfc := range arrIfc {
+		subResult := &ObligationsNode{
+			Kind: ObligationsEmpty,
+		}
+
+		subArrIfc, ok := subIfc.([]interface{})
+		if !ok {
+			return nil, ErrInvalidObligations
+		}
+
+		for _, itemIfc := range subArrIfc {
+			s, ok := itemIfc.(string)
+			if !ok {
+				return nil, ErrInvalidObligations
+			}
+
+			leafNode := &ObligationsNode{
+				Kind:      ObligationsCondition,
+				Condition: s,
+			}
+
+			if subResult.Children == nil {
+				subResult.Kind = ObligationsOr
+				subResult.Children = []*ObligationsNode{}
+			}
+			subResult.Children = append(subResult.Children, leafNode)
+		}
+
+		if subResult.ShallowLength() > 0 {
+			if result.Children == nil {
+				result.Kind = ObligationsOr
+				result.Children = []*ObligationsNode{}
+			}
+			result.Children = append(result.Children, subResult)
+		}
+	}
+
+	return result, nil
+}
+
+// obligations json.Unmarshal()'d as type:
+// map[string]interface {}{"policy1_guid":map[string]interface {}{"stmt0":[]interface {}{"ctx.metric == \"dhcp\""}}}
+func parseObligationsMap(mapIfc map[string]interface{}) (*ObligationsNode, error) {
+	if IsNilInterface(mapIfc) {
+		return nil, nil
+	}
+
+	rootNode := &ObligationsNode{
+		Kind: ObligationsEmpty,
+	}
+
+	for policyName, subIfc := range mapIfc {
+		stmtMapIfc, ok := subIfc.(map[string]interface{})
+		if !ok {
+			return nil, ErrInvalidObligations
+		}
+
+		policyNode := &ObligationsNode{
+			Kind: ObligationsEmpty,
+			Tag:  policyName,
+		}
+
+		for stmtName, stmtIfc := range stmtMapIfc {
+			subArrIfc, ok := stmtIfc.([]interface{})
+			if !ok {
+				return nil, ErrInvalidObligations
+			}
+
+			stmtNode := &ObligationsNode{
+				Kind: ObligationsEmpty,
+				Tag:  stmtName,
+			}
+
+			for _, itemIfc := range subArrIfc {
+				s, ok := itemIfc.(string)
+				if !ok {
+					return nil, ErrInvalidObligations
+				}
+
+				leafNode := &ObligationsNode{
+					Kind:      ObligationsCondition,
+					Condition: s,
+				}
+
+				if stmtNode.Children == nil {
+					stmtNode.Kind = ObligationsOr
+					stmtNode.Children = []*ObligationsNode{}
+				}
+				stmtNode.Children = append(stmtNode.Children, leafNode)
+			}
+
+			if stmtNode.ShallowLength() > 0 {
+				if policyNode.Children == nil {
+					policyNode.Kind = ObligationsOr
+					policyNode.Children = []*ObligationsNode{}
+				}
+				policyNode.Children = append(policyNode.Children, stmtNode)
+			}
+		}
+
+		if policyNode.ShallowLength() > 0 {
+			if rootNode.Children == nil {
+				rootNode.Kind = ObligationsOr
+				rootNode.Children = []*ObligationsNode{}
+			}
+			rootNode.Children = append(rootNode.Children, policyNode)
+		}
+	}
+
+	return rootNode, nil
+}
+
+// IsNilInterface returns whether the interface parameter is nil
+// Panics if arg is not chan, func, interface, map, pointer, or slice.
+// See https://golang.org/pkg/reflect/#Value.IsNil
+func IsNilInterface(i interface{}) bool {
+	return i == nil || reflect.ValueOf(i).IsNil()
+}

--- a/grpc_opa/obligations_test.go
+++ b/grpc_opa/obligations_test.go
@@ -1,0 +1,371 @@
+package grpc_opa_middleware
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Test_parseOPAObligations(t *testing.T) {
+	for idx, tst := range obligationsNodeTests {
+		var resp OPAResponse
+
+		err := json.Unmarshal([]byte(tst.regoRespJSON), &resp)
+		if err != nil {
+			t.Errorf("tst#%d: err=%s trying to json.Unmarshal: %s",
+				idx, err, tst.regoRespJSON)
+			continue
+		}
+
+		t.Logf("tst#%d: resp=%#v", idx, resp)
+		if _, ok := resp[string(ObKey)]; !ok {
+			if strings.Contains(tst.regoRespJSON, `"obligations":`) {
+				t.Errorf("tst#%d: '%s' key not found in OPAResponse",
+					idx, string(ObKey))
+			}
+			continue
+		}
+		actualVal, actualErr := parseOPAObligations(resp[string(ObKey)])
+
+		if actualErr != tst.expectedErr {
+			t.Errorf("tst#%d: expectedErr=%s actualErr=%s",
+				idx, tst.expectedErr, actualErr)
+		}
+
+		if actualVal != nil {
+			t.Logf("tst#%d: before DeepSort: %s", idx, actualVal)
+			actualVal.DeepSort()
+		}
+		if !reflect.DeepEqual(actualVal, tst.expectedVal) {
+			t.Errorf("tst#%d: expectedVal=%s\nactualVal=%s",
+				idx, tst.expectedVal, actualVal)
+		}
+	}
+}
+
+var obligationsNodeTests = []struct {
+	expectedErr  error
+	regoRespJSON string
+	expectedVal  *ObligationsNode
+}{
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": "bad obligations value"
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": [ "bad obligations value" ]
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": [ [ 3.14 ] ]
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": { "policy1_guid": "bad obligations value" }
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": { "bad_obligations_value": [ 3.14 ]}
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  ErrInvalidObligations,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": { "policy1_guid": { "stmt0": "bad obligations value" }}
+		}`,
+		expectedVal:  nil,
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": []
+		}`,
+		expectedVal:  &ObligationsNode{},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": [ [], [] ]
+		}`,
+		expectedVal:  &ObligationsNode{},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": [ [], [ "a" ] ]
+		}`,
+		expectedVal:  &ObligationsNode{
+			Kind: ObligationsOr,
+			Children: []*ObligationsNode{
+				&ObligationsNode{
+					Kind: ObligationsOr,
+					Children: []*ObligationsNode{
+						&ObligationsNode{
+							Kind: ObligationsCondition,
+							Condition: "a",
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": [ [ "a", "b" ], [ "c" ] ]
+		}`,
+		expectedVal:  &ObligationsNode{
+			Kind: ObligationsOr,
+			Children: []*ObligationsNode{
+				&ObligationsNode{
+					Kind: ObligationsOr,
+					Children: []*ObligationsNode{
+						&ObligationsNode{
+							Kind: ObligationsCondition,
+							Condition: "c",
+						},
+					},
+				},
+				&ObligationsNode{
+					Kind: ObligationsOr,
+					Children: []*ObligationsNode{
+						&ObligationsNode{
+							Kind: ObligationsCondition,
+							Condition: "a",
+						},
+						&ObligationsNode{
+							Kind: ObligationsCondition,
+							Condition: "b",
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": {}
+		}`,
+		expectedVal:  &ObligationsNode{},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": {
+				"policy1_guid": {},
+				"policy2_guid": {}
+			}
+		}`,
+		expectedVal:  &ObligationsNode{},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": {
+				"policy1_guid": {},
+				"policy2_guid": {
+					"stmt1": []
+				}
+			}
+		}`,
+		expectedVal:  &ObligationsNode{},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": {
+				"policy1_guid": {
+					"stmt0": []
+				},
+				"policy2_guid": {
+					"stmt1": []
+				}
+			}
+		}`,
+		expectedVal:  &ObligationsNode{},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": {
+				"policy1_guid": {
+					"stmt0": [ "i", "j" ]
+				},
+				"policy2_guid": {}
+			}
+		}`,
+		expectedVal:  &ObligationsNode{
+			Kind: ObligationsOr,
+			Children: []*ObligationsNode{
+				&ObligationsNode{
+					Kind: ObligationsOr,
+					Tag: "policy1_guid",
+					Children: []*ObligationsNode{
+						&ObligationsNode{
+							Kind: ObligationsOr,
+							Tag: "stmt0",
+							Children: []*ObligationsNode{
+								&ObligationsNode{
+									Kind: ObligationsCondition,
+									Condition: "i",
+								},
+								&ObligationsNode{
+									Kind: ObligationsCondition,
+									Condition: "j",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": {
+				"policy1_guid": {
+					"stmt0": [ "i", "j", "k" ]
+				},
+				"policy2_guid": {
+					"stmt1": []
+				}
+			}
+		}`,
+		expectedVal:  &ObligationsNode{
+			Kind: ObligationsOr,
+			Children: []*ObligationsNode{
+				&ObligationsNode{
+					Kind: ObligationsOr,
+					Tag: "policy1_guid",
+					Children: []*ObligationsNode{
+						&ObligationsNode{
+							Kind: ObligationsOr,
+							Tag: "stmt0",
+							Children: []*ObligationsNode{
+								&ObligationsNode{
+									Kind: ObligationsCondition,
+									Condition: "i",
+								},
+								&ObligationsNode{
+									Kind: ObligationsCondition,
+									Condition: "j",
+								},
+								&ObligationsNode{
+									Kind: ObligationsCondition,
+									Condition: "k",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		expectedErr:  nil,
+		regoRespJSON: `{
+			"allow": true,
+			"obligations": {
+				"policy1_guid": {
+					"stmt0": [ "a" ]
+				},
+				"policy2_guid": {
+					"stmt0": [ "b", "c" ],
+					"stmt1": [ "d" ]
+				}
+			}
+		}`,
+		expectedVal:  &ObligationsNode{
+			Kind: ObligationsOr,
+			Children: []*ObligationsNode{
+				&ObligationsNode{
+					Kind: ObligationsOr,
+					Tag: "policy1_guid",
+					Children: []*ObligationsNode{
+						&ObligationsNode{
+							Kind: ObligationsOr,
+							Tag: "stmt0",
+							Children: []*ObligationsNode{
+								&ObligationsNode{
+									Kind: ObligationsCondition,
+									Condition: "a",
+								},
+							},
+						},
+					},
+				},
+				&ObligationsNode{
+					Kind: ObligationsOr,
+					Tag: "policy2_guid",
+					Children: []*ObligationsNode{
+						&ObligationsNode{
+							Kind: ObligationsOr,
+							Tag: "stmt0",
+							Children: []*ObligationsNode{
+								&ObligationsNode{
+									Kind: ObligationsCondition,
+									Condition: "b",
+								},
+								&ObligationsNode{
+									Kind: ObligationsCondition,
+									Condition: "c",
+								},
+							},
+						},
+						&ObligationsNode{
+							Kind: ObligationsOr,
+							Tag: "stmt1",
+							Children: []*ObligationsNode{
+								&ObligationsNode{
+									Kind: ObligationsCondition,
+									Condition: "d",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
```
$ make test
go vet ./...
go test ./...
ok      github.com/infobloxopen/atlas-authz-middleware/grpc_opa 0.010s
ok      github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client   (cached)
```
