### PR TITLE
pass request method to getDecisionInput handler

### DIFF
--- a/grpc_opa/server_interceptor.go
+++ b/grpc_opa/server_interceptor.go
@@ -47,7 +47,7 @@ func UnaryServerInterceptor(application string, opts ...Option) grpc.UnaryServer
 		)
 
 		for _, auther := range cfg.authorizer {
-			ok, newCtx, err = auther.Evaluate(ctx, info.FullMethod, auther.OpaQuery)
+			ok, newCtx, err = auther.Evaluate(ctx, info.FullMethod, req, auther.OpaQuery)
 			if err != nil {
 				logger.WithError(err).Errorf("unable_authorize %#v", auther)
 			}
@@ -97,7 +97,7 @@ func StreamServerInterceptor(application string, opts ...Option) grpc.StreamServ
 		)
 
 		for _, auther := range cfg.authorizer {
-			ok, newCtx, err = auther.Evaluate(stream.Context(), info.FullMethod, auther.OpaQuery)
+			ok, newCtx, err = auther.Evaluate(stream.Context(), info.FullMethod, info, auther.OpaQuery)
 			if err != nil {
 				logger.WithError(err).Error("unable_authorize")
 			}


### PR DESCRIPTION
This PR passes the request argument to GetDecisionInput. In the case of a GET request, this is needed so that the autoriser can fill out the context appropriately. 