### PR TITLE
ATLAS-10442 pass OPA payload instead of GRPC payload to OPA

### DIFF
--- a/grpc_opa/authorizer_test.go
+++ b/grpc_opa/authorizer_test.go
@@ -28,17 +28,17 @@ func Test_parseEndpoint(t *testing.T) {
 func Test_addObligations(t *testing.T) {
 	for idx, tst := range obligationsNodeTests {
 		ctx := context.Background()
-		var resp OPAResponse
+		var opaResp OPAResponse
 
-		err := json.Unmarshal([]byte(tst.regoRespJSON), &resp)
+		err := json.Unmarshal([]byte(tst.regoRespJSON), &opaResp)
 		if err != nil {
 			t.Errorf("tst#%d: err=%s trying to json.Unmarshal: %s",
 				idx, err, tst.regoRespJSON)
 			continue
 		}
 
-		t.Logf("tst#%d: resp=%#v", idx, resp)
-		newCtx, actualErr := addObligations(ctx, resp)
+		t.Logf("tst#%d: opaResp=%#v", idx, opaResp)
+		newCtx, actualErr := addObligations(ctx, opaResp)
 
 		if actualErr != tst.expectedErr {
 			t.Errorf("tst#%d: expectedErr=%s actualErr=%s",
@@ -64,17 +64,17 @@ func Test_addObligations(t *testing.T) {
 
 func TestOPAResponseObligations(t *testing.T) {
 	for idx, tst := range obligationsNodeTests {
-		var resp OPAResponse
+		var opaResp OPAResponse
 
-		err := json.Unmarshal([]byte(tst.regoRespJSON), &resp)
+		err := json.Unmarshal([]byte(tst.regoRespJSON), &opaResp)
 		if err != nil {
 			t.Errorf("tst#%d: err=%s trying to json.Unmarshal: %s",
 				idx, err, tst.regoRespJSON)
 			continue
 		}
 
-		t.Logf("tst#%d: resp=%#v", idx, resp)
-		actualVal, actualErr := resp.Obligations()
+		t.Logf("tst#%d: opaResp=%#v", idx, opaResp)
+		actualVal, actualErr := opaResp.Obligations()
 
 		if actualErr != tst.expectedErr {
 			t.Errorf("tst#%d: expectedErr=%s actualErr=%s",

--- a/grpc_opa/server_interceptor.go
+++ b/grpc_opa/server_interceptor.go
@@ -37,7 +37,7 @@ func UnaryServerInterceptor(application string, opts ...Option) grpc.UnaryServer
 		cfg.authorizer = []Authorizer{NewDefaultAuthorizer(application, opts...)}
 	}
 
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, grpcUnaryHandler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, grpcReq interface{}, info *grpc.UnaryServerInfo, grpcUnaryHandler grpc.UnaryHandler) (interface{}, error) {
 		logger := ctxlogrus.Extract(ctx)
 
 		var (
@@ -47,7 +47,7 @@ func UnaryServerInterceptor(application string, opts ...Option) grpc.UnaryServer
 		)
 
 		for _, auther := range cfg.authorizer {
-			ok, newCtx, err = auther.Evaluate(ctx, info.FullMethod, req, auther.OpaQuery)
+			ok, newCtx, err = auther.Evaluate(ctx, info.FullMethod, grpcReq, auther.OpaQuery)
 			if err != nil {
 				logger.WithError(err).Errorf("unable_authorize %#v", auther)
 			}
@@ -66,7 +66,7 @@ func UnaryServerInterceptor(application string, opts ...Option) grpc.UnaryServer
 		}
 
 		// TODO: pass along authz information through context
-		return grpcUnaryHandler(newCtx, req)
+		return grpcUnaryHandler(newCtx, grpcReq)
 	}
 }
 


### PR DESCRIPTION
https://github.com/infobloxopen/atlas-authz-middleware/commit/e55a92501bf5b86fece939765dc4a1dfa49541af introduced a bug where it mistakenly passed the GRPC payload instead of OPA payload to OPA for evaluation.

Also renamed the generic req/resp variable names so they're more descriptive of their intention.

```
$ make test
go vet ./...
go test ./...
ok      github.com/infobloxopen/atlas-authz-middleware/grpc_opa 0.010s
ok      github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client   (cached)
```