### PR TITLE
ATLAS-10527: add public non-interceptor unary authz api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+### Direct (Non-GRPC-Interceptor) Usage
+
+```go
+import opamw "github.com/infobloxopen/atlas-authz-middleware/grpc_opa"
+
+// Create Authorizer with example options
+authzer := opamw.NewDefaultAuthorizer(
+    viper.GetString("app.id"),
+    opamw.WithAddress(opa_client.DefaultAddress),
+    opamw.WithDecisionInputHandler(&myDecisionInputer{}),
+)
+
+// AffirmAuthorization makes an authz request to sidecar-OPA.
+// If authorization is permitted, error returned is nil,
+// and a new context is returned, possibly containing obligations.
+// Caller must further evaluate obligations if required.
+newCtx, err := authzer.AffirmAuthorization(ctx, "MyService.MyMethod", nil)
+
+if err == nil {
+    // Operation is permitted, fetch and process obligations
+    if newCtx != nil {
+        obVal := newCtx.Value(opamw.ObKey)
+        if obVal != nil {
+            obTree, ok := obVal.(opamw.ObligationsNode)
+            if ok && obTree != nil {
+                // process any obligations in obTree if required
+            }
+        }
+    }
+}
+```
+
+### GRPC Unary Interceptor Usage
+
+```go
+import opamw "github.com/infobloxopen/atlas-authz-middleware/grpc_opa"
+
+// Create unary-interceptor with example options
+authzOpaInterceptor := opamw.UnaryServerInterceptor(
+    viper.GetString("app.id"),
+    opamw.WithAddress(opa_client.DefaultAddress),
+    opamw.WithDecisionInputHandler(&myDecisionInputer{}),
+)
+
+interceptors = append(interceptors, authzOpaInterceptor)
+```

--- a/grpc_opa/options.go
+++ b/grpc_opa/options.go
@@ -22,6 +22,14 @@ func WithHTTPClient(client *http.Client) Option {
 	}
 }
 
+// WithOpaEvaluator overrides the OpaEvaluator use to
+// evaluate authorization against OPA.
+func WithOpaEvaluator(opaEvaluator OpaEvaluator) Option {
+	return func(c *Config) {
+		c.opaEvaluator = opaEvaluator
+	}
+}
+
 // WithAuthorizer overrides the request/response
 // processing of OPA. Multiple authorizers can be passed
 func WithAuthorizer(auther ...Authorizer) Option {

--- a/pkg/opa_client/http.go
+++ b/pkg/opa_client/http.go
@@ -25,7 +25,7 @@ var (
 	ErrUndefined = errors.New("undefined decision")
 )
 
-// CLient implements the Clienter interface
+// Client implements the Clienter interface
 type Client struct {
 	cli     *http.Client
 	address string


### PR DESCRIPTION
Replaces https://github.com/infobloxopen/atlas-authz-middleware/pull/8

```
$ make test
go vet ./...
go test ./...
ok      github.com/infobloxopen/atlas-authz-middleware/grpc_opa 0.009s
ok      github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client   (cached)
```