### PR TITLE
Fix ATLAS-11094 by dumping fields where possible.

### DIFF
--- a/grpc_opa/authorizer.go
+++ b/grpc_opa/authorizer.go
@@ -54,10 +54,17 @@ type DecisionInputHandler interface {
 	// GetDecisionInput returns an app/service-specific DecisionInput.
 	// A nil DecisionInput should NOT be returned unless error.
 	GetDecisionInput(ctx context.Context, fullMethod string, grpcReq interface{}) (*DecisionInput, error)
+
+	// String implements fmt.Stringer interface
+	String() string
 }
 
 // DefaultDecisionInputer is an example DecisionInputHandler that is used as default
 type DefaultDecisionInputer struct{}
+
+func (m DefaultDecisionInputer) String() string {
+	return "grpc_opa_middleware.DefaultDecisionInputer{}"
+}
 
 // GetDecisionInput is an example DecisionInputHandler that returns some decision input
 // based on some incoming Context values.  App/services will most likely supply their
@@ -97,6 +104,9 @@ type Authorizer interface {
 	// OpaQuery executes query of the specified decisionDocument against OPA.
 	// If decisionDocument is "", then the query is executed against the default decision document configured in OPA.
 	OpaQuery(ctx context.Context, decisionDocument string, opaReq, opaResp interface{}) error
+
+	// String implements fmt.Stringer interface
+	String() string
 }
 
 type AuthorizeFn func(ctx context.Context, fullMethodName string, grpcReq interface{}, opaEvaluator OpaEvaluator) (bool, context.Context, error)
@@ -113,6 +123,7 @@ func NewDefaultAuthorizer(application string, opts ...Option) *DefaultAuthorizer
 	cfg := &Config{
 		address:              opa_client.DefaultAddress,
 		decisionInputHandler: defDecisionInputer,
+		claimsVerifier:       UnverifiedClaimFromBearers,
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -120,11 +131,17 @@ func NewDefaultAuthorizer(application string, opts ...Option) *DefaultAuthorizer
 
 	//log.Debugf("cfg=%+v", *cfg)
 
+	clienter := cfg.clienter
+	if cfg.clienter == nil {
+		clienter = opa_client.New(cfg.address, opa_client.WithHTTPClient(cfg.httpCli))
+	}
+
 	a := DefaultAuthorizer{
-		clienter:             opa_client.New(cfg.address, opa_client.WithHTTPClient(cfg.httpCli)),
+		clienter:             clienter,
 		opaEvaluator:         cfg.opaEvaluator,
 		application:          application,
 		decisionInputHandler: cfg.decisionInputHandler,
+		claimsVerifier:       cfg.claimsVerifier,
 	}
 	return &a
 }
@@ -134,6 +151,7 @@ type DefaultAuthorizer struct {
 	clienter             opa_client.Clienter
 	opaEvaluator         OpaEvaluator
 	decisionInputHandler DecisionInputHandler
+	claimsVerifier       ClaimsVerifier
 }
 
 type Config struct {
@@ -141,12 +159,14 @@ type Config struct {
 	// address to opa
 	address string
 
+	clienter             opa_client.Clienter
 	opaEvaluator         OpaEvaluator
 	authorizer           []Authorizer
 	decisionInputHandler DecisionInputHandler
+	claimsVerifier       ClaimsVerifier
 }
 
-var claimsVerifier func([]string, []string) (string, []error)
+type ClaimsVerifier func([]string, []string) (string, []error)
 
 // 	FullMethod is the full RPC method string, i.e., /package.service/method.
 // e.g. fullmethod:  /service.TagService/ListRetiredTags PARGs endpoint: TagService/ListRetiredTags
@@ -154,6 +174,11 @@ func parseEndpoint(fullMethod string) string {
 	byPackage := strings.Split(fullMethod, ".")
 	endpoint := byPackage[len(byPackage)-1]
 	return strings.Replace(endpoint, "/", ".", -1)
+}
+
+func (a DefaultAuthorizer) String() string {
+	return fmt.Sprintf(`grpc_opa_middleware.DefaultAuthorizer{application:"%s" clienter:%s decisionInputHandler:%s}`,
+		a.application, a.clienter.String(), a.decisionInputHandler.String())
 }
 
 func (a *DefaultAuthorizer) Evaluate(ctx context.Context, fullMethod string, grpcReq interface{}, opaEvaluator OpaEvaluator) (bool, context.Context, error) {
@@ -164,11 +189,7 @@ func (a *DefaultAuthorizer) Evaluate(ctx context.Context, fullMethod string, grp
 
 	bearer, newBearer := athena_claims.AuthBearersFromCtx(ctx)
 
-	if claimsVerifier == nil {
-		claimsVerifier = UnverifiedClaimFromBearers
-	}
-
-	rawJWT, errs := claimsVerifier([]string{bearer}, []string{newBearer})
+	rawJWT, errs := a.claimsVerifier([]string{bearer}, []string{newBearer})
 	if len(errs) > 0 {
 		return false, ctx, fmt.Errorf("%q", errs)
 	}
@@ -237,6 +258,23 @@ func (a *DefaultAuthorizer) Evaluate(ctx context.Context, fullMethod string, grp
 		return false, ctx, err
 	}
 
+	// When we query OPA for the default decision document, it returns non-nested JSON document:
+	//   {"allow": true, ...}
+	// When we query OPA for non-default decision document, it returns nested JSON document:
+	//   {"result":{"allow": true, ...}}
+	// If the JSON result document is nested within "result" wrapper map,
+	// we extract the nested JSON document and throw away the "result" wrapper map.
+	nestedResultVal, resultIsNested := opaResp["result"]
+	if resultIsNested {
+		nestedResultMap, ok := nestedResultVal.(map[string]interface{})
+		if ok {
+			opaResp = OPAResponse{}
+			for k, v := range nestedResultMap {
+				opaResp[k] = v
+			}
+		}
+	}
+
 	// Log non-err opa responses
 	{
 		raw, _ := json.Marshal(opaResp)
@@ -293,7 +331,7 @@ func (a *DefaultAuthorizer) AffirmAuthorization(ctx context.Context, fullMethod 
 
 	ok, newCtx, err = a.Evaluate(ctx, fullMethod, grpcReq, a.OpaQuery)
 	if err != nil {
-		logger.WithError(err).Errorf("unable_authorize %#v", a)
+		logger.WithError(err).Errorf("unable_authorize %s", a)
 		return nil, err
 	}
 

--- a/grpc_opa/authorizer_test.go
+++ b/grpc_opa/authorizer_test.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 	"reflect"
 	"testing"
+
+	"github.com/infobloxopen/atlas-authz-middleware/utils_test"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	logrus "github.com/sirupsen/logrus"
+	logrustesthook "github.com/sirupsen/logrus/hooks/test"
 )
 
 func TestRedactJWT(t *testing.T) {
@@ -47,7 +53,7 @@ func Test_addObligations(t *testing.T) {
 				idx, tst.expectedErr, actualErr)
 		}
 
-	        actualVal, _ := newCtx.Value(ObKey).(*ObligationsNode)
+		actualVal, _ := newCtx.Value(ObKey).(*ObligationsNode)
 		if actualVal != nil {
 			t.Logf("tst#%d: before DeepSort: %s", idx, actualVal)
 			actualVal.DeepSort()
@@ -96,7 +102,6 @@ func TestOPAResponseObligations(t *testing.T) {
 
 func TestAffirmAuthorization(t *testing.T) {
 	ErrBoom := errors.New("boom")
-	claimsVerifier = nullClaimsVerifier
 
 	testMap := []struct {
 		name        string
@@ -146,10 +151,14 @@ func TestAffirmAuthorization(t *testing.T) {
 		},
 	}
 
-	ctx := context.WithValue(context.Background(), TestingTContextKey, t)
+	ctx := context.WithValue(context.Background(), utils_test.TestingTContextKey, t)
+	ctx = ctxlogrus.ToContext(ctx, logrus.NewEntry(logrus.StandardLogger()))
 
 	for nth, tm := range testMap {
-		auther := NewDefaultAuthorizer("app", WithOpaEvaluator(tm.opaEvaltor))
+		auther := NewDefaultAuthorizer("app",
+			WithOpaEvaluator(tm.opaEvaltor),
+			WithClaimsVerifier(utils_test.NullClaimsVerifier),
+		)
 
 		resultCtx, resultErr := auther.AffirmAuthorization(ctx, "FakeMethod", nil)
 		if resultErr != tm.expectedErr {
@@ -163,3 +172,139 @@ func TestAffirmAuthorization(t *testing.T) {
 		}
 	}
 }
+
+func TestDebugLogging(t *testing.T) {
+	testMap := []struct {
+		name         string
+		regoRespJSON string
+		expectErr    bool
+		qryLogLvl    logrus.Level
+		qryLogMsg    string
+		qryOpaResp   string
+		evalLogLvl   logrus.Level
+		evalLogMsg   string
+		evalOpaResp  string
+	}{
+		{
+			name:         `valid rego object and valid response json object`,
+			regoRespJSON: `{"allow": true, "obligations": {"policy1": {}}}`,
+			expectErr:    false,
+			qryLogLvl:    logrus.DebugLevel,
+			qryLogMsg:    `opa_policy_engine_response`,
+			qryOpaResp:   `&map[allow:true obligations:map[policy1:map[]]]`,
+			evalLogLvl:   logrus.DebugLevel,
+			evalLogMsg:   `authorization_result`,
+			evalOpaResp:  `map[allow:true obligations:map[policy1:map[]]]`,
+		},
+		{
+			name:         `valid rego set but invalid json set`,
+			regoRespJSON: `{"allow": true, "obligations": {"policy1", "policy2"}}`,
+			expectErr:    true,
+			qryLogLvl:    logrus.ErrorLevel,
+			qryLogMsg:    `opa_policy_engine_request_error`,
+			qryOpaResp:   ``,
+			evalLogLvl:   logrus.DebugLevel,
+			evalLogMsg:   `authorization_result`,
+			evalOpaResp:  `map[]`,
+		},
+		{
+			name:         `valid rego array and valid response json array`,
+			regoRespJSON: `{"allow": true, "obligations": []}`,
+			expectErr:    false,
+			qryLogLvl:    logrus.DebugLevel,
+			qryLogMsg:    `opa_policy_engine_response`,
+			qryOpaResp:   `&map[allow:true obligations:[]]`,
+			evalLogLvl:   logrus.DebugLevel,
+			evalLogMsg:   `authorization_result`,
+			evalOpaResp:  `map[allow:true obligations:[]]`,
+		},
+	}
+
+	loggertesthook := logrustesthook.NewGlobal()
+	ctx := context.WithValue(context.Background(), utils_test.TestingTContextKey, t)
+	ctx = ctxlogrus.ToContext(ctx, logrus.NewEntry(logrus.StandardLogger()))
+
+	for nth, tm := range testMap {
+		mockOpaClienter := MockOpaClienter{
+			RegoRespJSON: tm.regoRespJSON,
+		}
+		auther := NewDefaultAuthorizer("app",
+			WithOpaClienter(&mockOpaClienter),
+			WithClaimsVerifier(utils_test.NullClaimsVerifier),
+		)
+		loggertesthook.Reset()
+
+		_, resultErr := auther.AffirmAuthorization(ctx, "FakeMethod", nil)
+		if !tm.expectErr && resultErr != nil {
+			t.Errorf("%d: %q: got unexpected error: %s", nth, tm.name, resultErr)
+		}
+		if tm.expectErr && resultErr == nil {
+			t.Errorf("%d: %q: expected error, but got no error", nth, tm.name)
+		}
+
+		gotOpaQryLogMsg := false
+		gotOpaEvalLogMsg := false
+		for eth, entry := range loggertesthook.AllEntries() {
+			t.Logf("%d: %q: [%d]logrus.Entry.Level: %s", nth, tm.name, eth, entry.Level)
+			t.Logf("%d: %q: [%d]logrus.Entry.Message: %s", nth, tm.name, eth, entry.Message)
+			t.Logf("%d: %q: [%d]logrus.Entry.Data: %s", nth, tm.name, eth, entry.Data)
+
+			opaResp, gotOpaResp := entry.Data["opaResp"]
+			entryOpaRespStr := fmt.Sprint(opaResp)
+			if gotOpaResp {
+				t.Logf("%d: %q: [%d]logrus.Entry.Data[opaResp]: %s", nth, tm.name, eth, entryOpaRespStr)
+			}
+
+			if entry.Level == tm.qryLogLvl && entry.Message == tm.qryLogMsg {
+				gotOpaQryLogMsg = true
+				if len(tm.qryOpaResp) > 0 && gotOpaResp && entryOpaRespStr != tm.qryOpaResp {
+					gotOpaQryLogMsg = false
+				}
+				continue
+			}
+
+			if entry.Level == tm.evalLogLvl && entry.Message == tm.evalLogMsg {
+				gotOpaEvalLogMsg = true
+				if len(tm.evalOpaResp) > 0 && gotOpaResp && entryOpaRespStr != tm.evalOpaResp {
+					gotOpaEvalLogMsg = false
+				}
+				continue
+			}
+		}
+
+		if !gotOpaQryLogMsg {
+			t.Errorf("%d: %q: Did not get OpaQuery logrus.Entry.Level/Message/opaResp: %s/`%s`/`%s`",
+				nth, tm.name, tm.qryLogLvl, tm.qryLogMsg, tm.qryOpaResp)
+		}
+
+		if !gotOpaEvalLogMsg {
+			t.Errorf("%d: %q: Did not get Evaluate logrus.Entry.Level/Message/opaResp: %s/`%s`/`%s`",
+				nth, tm.name, tm.evalLogLvl, tm.evalLogMsg, tm.evalOpaResp)
+		}
+	}
+}
+
+type MockOpaClienter struct{
+	RegoRespJSON string
+}
+
+func (m MockOpaClienter) String() string {
+	return fmt.Sprintf(`MockOpaClienter{RegoRespJSON:"%s"}`, m.RegoRespJSON)
+}
+
+func (m MockOpaClienter) Address() string {
+	return "http://localhost:8181"
+}
+
+func (m MockOpaClienter) Health() error {
+	return nil
+}
+
+func (m MockOpaClienter) Query(ctx context.Context, data interface{}, resp interface{}) error {
+	return m.CustomQuery(ctx, "", data, resp)
+}
+
+func (m MockOpaClienter) CustomQuery(ctx context.Context, document string, data interface{}, resp interface{}) error {
+	return json.Unmarshal([]byte(m.RegoRespJSON), resp)
+}
+

--- a/grpc_opa/options.go
+++ b/grpc_opa/options.go
@@ -2,6 +2,7 @@ package grpc_opa_middleware
 
 import (
 	"net/http"
+	"github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client"
 )
 
 type Option func(c *Config)
@@ -18,6 +19,16 @@ func WithHTTPClient(client *http.Client) Option {
 	return func(c *Config) {
 		if client != nil {
 			c.httpCli = client
+		}
+	}
+}
+
+// WithOpaClienter overrides the Clienter used to call Opa.
+// This option takes precedence over WithHTTPClient.
+func WithOpaClienter(clienter opa_client.Clienter) Option {
+	return func(c *Config) {
+		if clienter != nil {
+			c.clienter = clienter
 		}
 	}
 }
@@ -44,5 +55,12 @@ func WithAuthorizer(auther ...Authorizer) Option {
 func WithDecisionInputHandler(decisionHandler DecisionInputHandler) Option {
 	return func(c *Config) {
 		c.decisionInputHandler = decisionHandler
+	}
+}
+
+// WithClaimsVerifier overrides default ClaimsVerifier
+func WithClaimsVerifier(claimsVerifier ClaimsVerifier) Option {
+	return func(c *Config) {
+		c.claimsVerifier = claimsVerifier
 	}
 }

--- a/grpc_opa/server_interceptor.go
+++ b/grpc_opa/server_interceptor.go
@@ -49,7 +49,7 @@ func UnaryServerInterceptor(application string, opts ...Option) grpc.UnaryServer
 		for _, auther := range cfg.authorizer {
 			ok, newCtx, err = auther.Evaluate(ctx, info.FullMethod, grpcReq, auther.OpaQuery)
 			if err != nil {
-				logger.WithError(err).Errorf("unable_authorize %s", auther)
+				logger.WithError(err).WithField("authorizer", auther).Error("unable_authorize")
 			}
 			if ok {
 				break
@@ -99,7 +99,7 @@ func StreamServerInterceptor(application string, opts ...Option) grpc.StreamServ
 		for _, auther := range cfg.authorizer {
 			ok, newCtx, err = auther.Evaluate(stream.Context(), info.FullMethod, info, auther.OpaQuery)
 			if err != nil {
-				logger.WithError(err).Errorf("unable_authorize %s", auther)
+				logger.WithError(err).WithField("authorizer", auther).Error("unable_authorize")
 			}
 			if ok {
 				break

--- a/grpc_opa/server_interceptor.go
+++ b/grpc_opa/server_interceptor.go
@@ -49,7 +49,7 @@ func UnaryServerInterceptor(application string, opts ...Option) grpc.UnaryServer
 		for _, auther := range cfg.authorizer {
 			ok, newCtx, err = auther.Evaluate(ctx, info.FullMethod, grpcReq, auther.OpaQuery)
 			if err != nil {
-				logger.WithError(err).Errorf("unable_authorize %#v", auther)
+				logger.WithError(err).Errorf("unable_authorize %s", auther)
 			}
 			if ok {
 				break
@@ -99,7 +99,7 @@ func StreamServerInterceptor(application string, opts ...Option) grpc.StreamServ
 		for _, auther := range cfg.authorizer {
 			ok, newCtx, err = auther.Evaluate(stream.Context(), info.FullMethod, info, auther.OpaQuery)
 			if err != nil {
-				logger.WithError(err).Error("unable_authorize")
+				logger.WithError(err).Errorf("unable_authorize %s", auther)
 			}
 			if ok {
 				break

--- a/grpc_opa/server_interceptor_test.go
+++ b/grpc_opa/server_interceptor_test.go
@@ -13,15 +13,15 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	logrus "github.com/sirupsen/logrus"
+	logrustesthook "github.com/sirupsen/logrus/hooks/test"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client"
+	"github.com/infobloxopen/atlas-authz-middleware/utils_test"
 )
-
-type TestingTContextKeyType string
-const TestingTContextKey = TestingTContextKeyType("*testing.T")
 
 var netDialErr = &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED}
 
@@ -38,22 +38,23 @@ func init() {
 	logrus.SetLevel(logrus.DebugLevel)
 }
 
+/*
 func nullClaimsVerifier([]string, []string) (string, []error) {
 	return "", nil
 }
+*/
 
 func TestConnFailure(t *testing.T) {
-	claimsVerifier = nullClaimsVerifier
-
 	grpcUnaryHandler := func(ctx context.Context, grpcReq interface{}) (interface{}, error) {
 		return nil, nil
 	}
-	interceptor := UnaryServerInterceptor("app", WithHTTPClient(&http.Client{
-		Transport: &connFailTransport{},
-	}))
+	interceptor := UnaryServerInterceptor("app",
+		WithHTTPClient(&http.Client{Transport: &connFailTransport{},}),
+		WithClaimsVerifier(utils_test.NullClaimsVerifier),
+	)
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(3*time.Second))
-	ctx = context.WithValue(ctx, TestingTContextKey, t)
+	ctx = context.WithValue(ctx, utils_test.TestingTContextKey, t)
 	defer cancel()
 	grpcResp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "FakeMethod"}, grpcUnaryHandler)
 	if grpcResp != nil {
@@ -66,18 +67,19 @@ func TestConnFailure(t *testing.T) {
 }
 
 func TestMockOPA(t *testing.T) {
-	claimsVerifier = nullClaimsVerifier
-
 	grpcUnaryHandler := func(ctx context.Context, grpcReq interface{}) (interface{}, error) {
 		return nil, nil
 	}
 
 	mock := new(mockAuthorizer)
-	interceptor := UnaryServerInterceptor("app", WithAuthorizer(mock))
+	interceptor := UnaryServerInterceptor("app",
+		WithAuthorizer(mock),
+		WithClaimsVerifier(utils_test.NullClaimsVerifier),
+	)
 
 	deadline := time.Now().Add(3 * time.Second)
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
-	ctx = context.WithValue(ctx, TestingTContextKey, t)
+	ctx = context.WithValue(ctx, utils_test.TestingTContextKey, t)
 	defer cancel()
 	testMap := []struct {
 		code   codes.Code
@@ -115,18 +117,19 @@ func (m *mockAuthorizer) Evaluate(ctx context.Context, fullMethod string, grpcRe
 }
 
 func TestStreamServerInterceptor(t *testing.T) {
-	claimsVerifier = nullClaimsVerifier
-
 	grpcStreamHandler := func(srv interface{}, stream grpc.ServerStream) error {
 		return nil
 	}
 
 	mock := new(mockAuthorizer)
-	interceptor := StreamServerInterceptor("app", WithAuthorizer(mock))
+	interceptor := StreamServerInterceptor("app",
+		WithAuthorizer(mock),
+		WithClaimsVerifier(utils_test.NullClaimsVerifier),
+	)
 
 	deadline := time.Now().Add(3 * time.Second)
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
-	ctx = context.WithValue(ctx, TestingTContextKey, t)
+	ctx = context.WithValue(ctx, utils_test.TestingTContextKey, t)
 	defer cancel()
 	testMap := []struct {
 		code   codes.Code
@@ -163,12 +166,16 @@ type mockAuthorizerWithAllowOpaEvaluator struct {
 	defAuther *DefaultAuthorizer
 }
 
+func (m mockAuthorizerWithAllowOpaEvaluator) String() string {
+	return fmt.Sprintf("mockAuthorizerWithAllowOpaEvaluator{defAuther:%s}", m.defAuther.String())
+}
+
 func (a *mockAuthorizerWithAllowOpaEvaluator) Evaluate(ctx context.Context, fullMethod string, grpcReq interface{}, opaEvaluator OpaEvaluator) (bool, context.Context, error) {
 	return a.defAuther.Evaluate(ctx, fullMethod, grpcReq, opaEvaluator)
 }
 
 func (m *mockAuthorizerWithAllowOpaEvaluator) OpaQuery(ctx context.Context, decisionDocument string, opaReq, opaResp interface{}) error {
-	t, _ := ctx.Value(TestingTContextKey).(*testing.T)
+	t, _ := ctx.Value(utils_test.TestingTContextKey).(*testing.T)
 	_, ok := opaReq.(Payload)
 	allow := "true"
 	if !ok {
@@ -187,11 +194,19 @@ func newMockAuthorizerWithAllowOpaEvaluator(application string, opts ...Option) 
 
 type badDecisionInputer struct{}
 
+func (m badDecisionInputer) String() string {
+	return "badDecisionInputer{}"
+}
+
 func (m *badDecisionInputer) GetDecisionInput(ctx context.Context, fullMethod string, grpcReq interface{}) (*DecisionInput, error) {
 	return nil, fmt.Errorf("badDecisionInputer")
 }
 
 type jsonMarshalableInputer struct{}
+
+func (m jsonMarshalableInputer) String() string {
+	return "jsonMarshalableInputer{}"
+}
 
 func (m *jsonMarshalableInputer) GetDecisionInput(ctx context.Context, fullMethod string, grpcReq interface{}) (*DecisionInput, error) {
 	var sealctx []interface{}
@@ -221,9 +236,13 @@ func (m *jsonMarshalableInputer) GetDecisionInput(ctx context.Context, fullMetho
 
 type jsonNonMarshalableInputer struct{}
 
+func (m jsonNonMarshalableInputer) String() string {
+	return "jsonNonMarshalableInputer{}"
+}
+
 func (m *jsonNonMarshalableInputer) GetDecisionInput(ctx context.Context, fullMethod string, grpcReq interface{}) (*DecisionInput, error) {
 	var sealctx []interface{}
-	sealctx = append(sealctx, nullClaimsVerifier) // nullClaimsVerifier is a non-json-marshalable fn)
+	sealctx = append(sealctx, utils_test.NullClaimsVerifier) // NullClaimsVerifier is a non-json-marshalable fn)
 
 	inp, _ := defDecisionInputer.GetDecisionInput(ctx, fullMethod, grpcReq)
 	inp.SealCtx = sealctx
@@ -232,14 +251,13 @@ func (m *jsonNonMarshalableInputer) GetDecisionInput(ctx context.Context, fullMe
 }
 
 func TestDecisionInput(t *testing.T) {
-	claimsVerifier = nil
-
 	testMap := []struct {
 		err       error
 		abacType  string
 		abacVerb  string
 		inputer   DecisionInputHandler
 		jwtHeader string
+		errLogMsg string
 	}{
 		{
 			err:      nil,
@@ -256,6 +274,7 @@ func TestDecisionInput(t *testing.T) {
 			inputer:  new(jsonNonMarshalableInputer),
 			// fake svc-svc jwt with fake signature
 			jwtHeader: "bearer eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzZXJ2aWNlIjoiZm9vLXNlcnZpY2UiLCJhdWQiOiJmb28tYXVkaWVuY2UiLCJleHAiOjIzOTg4NzI3NzgsImp0aSI6ImZvby1qdGkiLCJpYXQiOjE1MzUzMjE0MDcsImlzcyI6ImZvby1pc3N1ZXIiLCJuYmYiOjE1MzUzMjE0MDd9.4zcNzRrhIXN3s6jNYWIbe6TRBaOwTh_Yy1iSCqVW9H4pT3p2c23TSsLq6R2zs-xmsZ5jTUvalpQgPJwbFmdvxA",
+			errLogMsg: `unable_authorize mockAuthorizerWithAllowOpaEvaluator{defAuther:grpc_opa_middleware.DefaultAuthorizer{application:"myapplication" clienter:opa_client.Client{address:"http://localhost:8181"} decisionInputHandler:jsonNonMarshalableInputer{}}}`,
 		},
 		{
 			err:      ErrInvalidArg,
@@ -264,33 +283,54 @@ func TestDecisionInput(t *testing.T) {
 			inputer:  new(badDecisionInputer),
 			// empty jwt with fake signature
 			jwtHeader: "bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.A5mVf-_pE0XM6RlWnNx4YBzFWqYIcsc3_j1g9I2768c",
+			errLogMsg: `unable_authorize mockAuthorizerWithAllowOpaEvaluator{defAuther:grpc_opa_middleware.DefaultAuthorizer{application:"myapplication" clienter:opa_client.Client{address:"http://localhost:8181"} decisionInputHandler:badDecisionInputer{}}}`,
 		},
 	}
 
-	for _, tm := range testMap {
+	loggertesthook := logrustesthook.NewGlobal()
+
+	for nth, tm := range testMap {
 		grpcUnaryHandler := func(ctx context.Context, grpcReq interface{}) (interface{}, error) {
 			return nil, nil
 		}
 
 		mockInputer := tm.inputer
 		mockAuthzer := newMockAuthorizerWithAllowOpaEvaluator("myapplication", WithDecisionInputHandler(mockInputer))
-		interceptor := UnaryServerInterceptor("app", WithAuthorizer(mockAuthzer), WithDecisionInputHandler(mockInputer))
+		interceptor := UnaryServerInterceptor("app",
+			WithAuthorizer(mockAuthzer),
+			WithDecisionInputHandler(mockInputer),
+			WithClaimsVerifier(utils_test.NullClaimsVerifier),
+		)
 
 		headers := map[string]string{
 			"authorization": tm.jwtHeader,
 		}
 
 		ctx := context.Background()
-		ctx = context.WithValue(ctx, TestingTContextKey, t)
+		ctx = context.WithValue(ctx, utils_test.TestingTContextKey, t)
 		ctx = context.WithValue(ctx, TypeKey, tm.abacType)
 		ctx = context.WithValue(ctx, VerbKey, tm.abacVerb)
 		ctx = ctxlogrus.ToContext(ctx, logrus.NewEntry(logrus.StandardLogger()))
 		ctx = metadata.NewIncomingContext(ctx, metadata.New(headers))
 
+		loggertesthook.Reset()
+
 		_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "FakeService.FakeMethod"}, grpcUnaryHandler)
 		//t.Logf("err=%+v tm.err=%+v", err, tm.err)
 		if err != tm.err {
-			t.Errorf("got: %s wanted: %s", err, tm.err)
+			t.Errorf("%d: got: %s wanted: %s", nth, err, tm.err)
+		} else if err != nil {
+			gotExpectedErrLogMsg := false
+			for _, entry := range loggertesthook.AllEntries() {
+				t.Logf("%d: logrus.Entry.Message: %s", nth, entry.Message)
+				if entry.Message == tm.errLogMsg {
+					gotExpectedErrLogMsg = true
+					break
+				}
+			}
+			if !gotExpectedErrLogMsg {
+				t.Errorf("%d: Did not get logrus.Entry.Message: `%s`", nth, tm.errLogMsg)
+			}
 		}
 	}
 }

--- a/pkg/opa_client/http.go
+++ b/pkg/opa_client/http.go
@@ -40,7 +40,6 @@ type Clienter interface {
 	CustomQuery(ctx context.Context, document string, data interface{}, resp interface{}) error
 	Health() error
 	Query(ctx context.Context, data interface{}, resp interface{}) error
-	String() string
 }
 
 type Option func(c *Client)

--- a/pkg/opa_client/http.go
+++ b/pkg/opa_client/http.go
@@ -40,6 +40,7 @@ type Clienter interface {
 	CustomQuery(ctx context.Context, document string, data interface{}, resp interface{}) error
 	Health() error
 	Query(ctx context.Context, data interface{}, resp interface{}) error
+	String() string
 }
 
 type Option func(c *Client)
@@ -77,6 +78,11 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 	}
 
 	return resp, err
+}
+
+// String implements fmt.Stringer interface
+func (c Client) String() string {
+	return fmt.Sprintf(`opa_client.Client{address:"%s"}`, c.address)
 }
 
 // Address retrieves the protocol://address of server
@@ -165,4 +171,47 @@ func checkHeader(scheme, key, val string) bool {
 	}
 
 	return httpguts.ValidHeaderFieldName(key) && httpguts.ValidHeaderFieldValue(val)
+}
+
+// UploadRegoPolicy creates/updates an OPA policy.
+// Intended for unit-testing.
+//
+// https://www.openpolicyagent.org/docs/latest/rest-api/#create-or-update-a-policy
+func (c *Client) UploadRegoPolicy(ctx context.Context, policyID string, policyRego []byte, resp interface{}) error {
+
+	ref := fmt.Sprintf("%s/v1/policies/%s", c.Address(), policyID)
+
+	req, err := http.NewRequest("PUT", ref, bytes.NewBuffer(policyRego))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "text/plain")
+
+	putResp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer putResp.Body.Close()
+	bs, _ := ioutil.ReadAll(putResp.Body)
+
+	buf := bytes.NewBuffer(bs)
+	copy := buf.String()
+	dec := json.NewDecoder(buf)
+
+	// Successful code, decode as document
+	if putResp.StatusCode >= 200 && putResp.StatusCode < 400 {
+		if resp == nil {
+			return nil
+		}
+		return dec.Decode(resp)
+	}
+
+	// unsuccessful code, attempt to decode as types.ErrorV1
+	var opaErrV1 types.ErrorV1
+	if err := dec.Decode(&opaErrV1); err != nil {
+		return fmt.Errorf("unparseable error from OPA: StatusCode=%d: `%s`", putResp.StatusCode, copy)
+	}
+
+	return &opaErrV1
 }

--- a/pkg/opa_client/http_internal_test.go
+++ b/pkg/opa_client/http_internal_test.go
@@ -1,0 +1,36 @@
+package opa_client
+
+import (
+	"testing"
+)
+
+func TestCheckHeaders(t *testing.T) {
+	tests := []struct {
+		key string
+		val string
+		eOK bool
+	}{
+		{
+			// NGP-5595
+			eOK: false,
+			key: "Grpc-Trace-Bin",
+			val: "\x00\x00\xe7Z\xa0\xcd\xc4?\xdbT\x00\x00\x00\x00\x00\x00\x00\x00\x01",
+		},
+		{
+			eOK: false,
+			key: ":authority",
+			val: "",
+		},
+		{
+			eOK: true,
+			key: "Authorization",
+			val: "Bearer somestring",
+		},
+	}
+	for _, tm := range tests {
+		ok := checkHeader("http", tm.key, tm.val)
+		if tm.eOK != ok {
+			t.Errorf("got: %t wanted: %t", ok, tm.eOK)
+		}
+	}
+}

--- a/pkg/opa_client/http_test.go
+++ b/pkg/opa_client/http_test.go
@@ -1,25 +1,31 @@
-package opa_client
+package opa_client_test
 
 import (
 	"context"
 	"errors"
-	"net"
-	"os"
+	"io/ioutil"
 	"syscall"
 	"testing"
-	"time"
 
-	"github.com/open-policy-agent/opa/plugins"
-	"github.com/open-policy-agent/opa/server"
-	"github.com/open-policy-agent/opa/storage/inmem"
+	opamw "github.com/infobloxopen/atlas-authz-middleware/grpc_opa"
+	"github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client"
+	"github.com/infobloxopen/atlas-authz-middleware/utils_test"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	logrus "github.com/sirupsen/logrus"
 )
+
+
+func init() {
+	logrus.SetLevel(logrus.DebugLevel)
+}
 
 func TestRestAPI(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan struct{})
-	cli := startOpa(ctx, t, done)
+	cli := utils_test.StartOpa(ctx, t, done)
 
 	// Errors above here will leak containers
 	defer func() {
@@ -33,122 +39,85 @@ func TestRestAPI(t *testing.T) {
 	}
 }
 
-func startOpa(ctx context.Context, t *testing.T, done chan struct{}) Clienter {
-	// Retrieve a random port from the OS and pass it to opa
-	l, err := net.Listen("tcp4", ":0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := l.Addr().String()
-	l.Close()
-
-	addrs := []string{addr}
-
-	bs := []byte{}
-	store := inmem.New()
-	m, err := plugins.New(bs, "test", store)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := m.Start(ctx); err != nil {
-		t.Fatal(err)
-	}
-
-	opaSvr := server.New().
-		WithAddresses(addrs).
-		WithStore(store).
-		WithManager(m)
-
-	opaSvr, err = opaSvr.Init(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loops, err := opaSvr.Listeners()
-	if err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
-	}
-
-	errc := make(chan error)
-	for _, loop := range loops {
-		go func(serverLoop func() error) {
-			errc <- serverLoop()
-		}(loop)
-	}
-
-	go func() {
-		<-ctx.Done()
-
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-		defer cancel()
-		if err := opaSvr.Shutdown(shutdownCtx); err != nil {
-			t.Logf(err.Error())
-			os.Exit(1)
-		}
-		close(done)
-	}()
-
-	cli := New("http://" + addr)
-	timeout := time.After(3 * time.Second)
-	for {
-		select {
-		case <-timeout:
-			t.Fatal("time out starting opa")
-		default:
-			if err := cli.Health(); err == nil {
-				t.Logf("opa started")
-				return cli
-			}
-			t.Logf("opa not ready: %s", err)
-			time.Sleep(50 * time.Millisecond)
-		}
-	}
-}
-
-func TestCheckHeaders(t *testing.T) {
-	tests := []struct {
-		key string
-		val string
-		eOK bool
-	}{
-		{
-			// NGP-5595
-			eOK: false,
-			key: "Grpc-Trace-Bin",
-			val: "\x00\x00\xe7Z\xa0\xcd\xc4?\xdbT\x00\x00\x00\x00\x00\x00\x00\x00\x01",
-		},
-		{
-			eOK: false,
-			key: ":authority",
-			val: "",
-		},
-		{
-			eOK: true,
-			key: "Authorization",
-			val: "Bearer somestring",
-		},
-	}
-	for _, tm := range tests {
-		ok := checkHeader("http", tm.key, tm.val)
-		if tm.eOK != ok {
-			t.Errorf("got: %t wanted: %t", ok, tm.eOK)
-		}
-	}
-}
-
 func TestConnectionRefused(t *testing.T) {
 
-	cli := New("http://localhost:0001")
+	cli := opa_client.New("http://localhost:0001")
 	err := cli.Health()
 	if err == nil {
 		t.Error("unexpected nil err")
 	}
 
-	if _, ok := err.(*ErrorV1); !ok {
+	if _, ok := err.(*opa_client.ErrorV1); !ok {
 		t.Errorf("unexpected unstructured error: %#v", err)
 	}
 	if !errors.Is(err, syscall.ECONNREFUSED) {
 		t.Errorf("\ngot:    %#v\nwanted: %#v", err, syscall.ECONNREFUSED)
 	}
+}
+
+// Verify that legal Rego set values (eg: "{1,2,3}") are returned as
+// legal JSON array values (eg: "[1,2,3]") by OPA REST API
+func TestPolicyReturningRegoSet(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = context.WithValue(ctx, utils_test.TestingTContextKey, t)
+	ctx = ctxlogrus.ToContext(ctx, logrus.NewEntry(logrus.StandardLogger()))
+
+	done := make(chan struct{})
+	clienter := utils_test.StartOpa(ctx, t, done)
+	cli, ok := clienter.(*opa_client.Client)
+	if !ok {
+		t.Fatal("Unable to convert interface to (*Client)")
+		return
+	}
+
+	// Errors above here will leak containers
+	defer func() {
+		cancel()
+		// Wait for container to be shutdown
+		<-done
+	}()
+
+	policyRego, err := ioutil.ReadFile("testdata/policy_returning_set.rego")
+	if err != nil {
+		t.Fatalf("ReadFile fatal err: %#v", err)
+		return
+	}
+
+	var resp interface{}
+	err = cli.UploadRegoPolicy(ctx, "mypolicyid", policyRego, resp)
+	if err != nil {
+		t.Fatalf("OpaUploadPolicy fatal err: %#v", err)
+		return
+	}
+
+	mockDecInp := &MockDecisionInputer{}
+	auther := opamw.NewDefaultAuthorizer("app",
+		opamw.WithOpaClienter(cli),
+		opamw.WithDecisionInputHandler(mockDecInp),
+		opamw.WithClaimsVerifier(utils_test.NullClaimsVerifier),
+	)
+
+	// If authorization is permitted, then this verifies that the OPA JSON results were correctly decoded,
+	// and this verifies that the rego set result is returned by OPA as a JSON array result.
+	resultCtx, resultErr := auther.AffirmAuthorization(ctx, "FakeMethod", nil)
+	if resultErr != nil {
+		t.Errorf("AffirmAuthorization err: %#v", resultErr)
+	}
+	if resultCtx == nil {
+		t.Error("AffirmAuthorization returned nil context")
+	}
+}
+
+type MockDecisionInputer struct{}
+
+func (m MockDecisionInputer) String() string {
+	return "opa_client_test.MockDecisionInputer{}"
+}
+
+func (m *MockDecisionInputer) GetDecisionInput(ctx context.Context, fullMethod string, grpcReq interface{}) (*opamw.DecisionInput, error) {
+	decInp := opamw.DecisionInput{
+		DecisionDocument: "/v1/data/policy_returning_set/get_results",
+	}
+	return &decInp, nil
 }

--- a/pkg/opa_client/testdata/policy_returning_set.rego
+++ b/pkg/opa_client/testdata/policy_returning_set.rego
@@ -1,0 +1,29 @@
+# Sample Rego used to verify that Rego sets are returned as json arrays by OPA REST API.
+# See unit-test test_get_results, which verifies Rego set is returned.
+
+package policy_returning_set
+
+row_arr := [ `e`, `a`, `d`, `b`, `c`, ]
+
+row_set[item] {
+	item := row_arr[_]
+}
+
+get_results = {
+	"allow": true,
+	"row_set": row_set,
+}
+
+test_get_results {
+	results := get_results
+	trace(sprintf("results: %v", [results]))
+	row_arr == [ `e`, `a`, `d`, `b`, `c`, ]
+	results.row_set == { `d`, `c`, `a`, `b`, `e`, }
+	results.row_set != [ `e`, `a`, `d`, `b`, `c`, ]
+}
+
+# opa test -v policy_returning_set.rego
+# opa run --server policy_returning_set.rego
+# curl -X GET  -H 'Content-Type: application/json' http://localhost:8181/v1/data/policy_returning_set/get_results | jq .
+# curl -X POST -H 'Content-Type: application/json' http://localhost:8181/v1/data/policy_returning_set/get_results | jq .
+

--- a/utils_test/misc.go
+++ b/utils_test/misc.go
@@ -1,0 +1,8 @@
+package utils_test
+
+type TestingTContextKeyType string
+const TestingTContextKey = TestingTContextKeyType("*testing.T")
+
+func NullClaimsVerifier([]string, []string) (string, []error) {
+	return "", nil
+}

--- a/utils_test/opa_server.go
+++ b/utils_test/opa_server.go
@@ -1,0 +1,88 @@
+package utils_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client"
+
+	"github.com/open-policy-agent/opa/plugins"
+	"github.com/open-policy-agent/opa/server"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+func StartOpa(ctx context.Context, t *testing.T, done chan struct{}) opa_client.Clienter {
+	// Retrieve a random port from the OS and pass it to opa
+	l, err := net.Listen("tcp4", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	l.Close()
+
+	addrs := []string{addr}
+
+	bs := []byte{}
+	store := inmem.New()
+	m, err := plugins.New(bs, "test", store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	opaSvr := server.New().
+		WithAddresses(addrs).
+		WithStore(store).
+		WithManager(m)
+
+	opaSvr, err = opaSvr.Init(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loops, err := opaSvr.Listeners()
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	errc := make(chan error)
+	for _, loop := range loops {
+		go func(serverLoop func() error) {
+			errc <- serverLoop()
+		}(loop)
+	}
+
+	go func() {
+		<-ctx.Done()
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		if err := opaSvr.Shutdown(shutdownCtx); err != nil {
+			t.Logf(err.Error())
+			os.Exit(1)
+		}
+		close(done)
+	}()
+
+	cli := opa_client.New("http://" + addr)
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			t.Fatal("time out starting opa")
+		default:
+			if err := cli.Health(); err == nil {
+				t.Logf("opa started")
+				return cli
+			}
+			t.Logf("opa not ready: %s", err)
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}


### PR DESCRIPTION
Fix ATLAS-11094 by dumping fields where possible.
Fix parsing of nested result JSON doc when querying non-default OPA decision document.
Refactor/add unit-test to verify OPA REST API converts legal Rego set values to JSON array values.
```
$ make
go vet ./...
go test ./...
ok      github.com/infobloxopen/atlas-authz-middleware/grpc_opa (cached)
ok      github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client   0.023s
?       github.com/infobloxopen/atlas-authz-middleware/utils_test       [no test files]
```