### PR TITLE
Add WithExtraInputFields() option

### DIFF
--- a/grpc_opa/authorizer.go
+++ b/grpc_opa/authorizer.go
@@ -144,9 +144,12 @@ func NewDefaultAuthorizer(application string, opts ...Option) *DefaultAuthorizer
 		claimsVerifier:       cfg.claimsVerifier,
 		entitledServices:     cfg.entitledServices,
 		acctEntitlementsApi:  cfg.acctEntitlementsApi,
+		extraInputFields:     cfg.extraInputFields,
 	}
 	return &a
 }
+
+type ExtraInputFields map[string]interface{}
 
 type DefaultAuthorizer struct {
 	application          string
@@ -156,6 +159,7 @@ type DefaultAuthorizer struct {
 	claimsVerifier       ClaimsVerifier
 	entitledServices     []string
 	acctEntitlementsApi  string
+	extraInputFields     ExtraInputFields
 }
 
 type Config struct {
@@ -170,6 +174,7 @@ type Config struct {
 	claimsVerifier       ClaimsVerifier
 	entitledServices     []string
 	acctEntitlementsApi  string
+	extraInputFields     ExtraInputFields
 }
 
 type ClaimsVerifier func([]string, []string) (string, []error)
@@ -221,6 +226,7 @@ func (a *DefaultAuthorizer) Evaluate(ctx context.Context, fullMethod string, grp
 		JWT:              redactJWT(rawJWT),
 		RequestID:        reqID,
 		EntitledServices: a.entitledServices,
+		ExtraInputFields: a.extraInputFields,
 	}
 
 	decisionInput, err := a.decisionInputHandler.GetDecisionInput(ctx, fullMethod, grpcReq)
@@ -407,6 +413,7 @@ type Payload struct {
 	RequestID        string   `json:"request_id"`
 	EntitledServices []string `json:"entitled_services"`
 	DecisionInput
+	ExtraInputFields `json:"extra,omitempty"`
 }
 
 // OPARequest is used to query OPA

--- a/grpc_opa/options.go
+++ b/grpc_opa/options.go
@@ -79,3 +79,23 @@ func WithAcctEntitlementsApiPath(acctEntitlementsApi string) Option {
 		c.acctEntitlementsApi = acctEntitlementsApi
 	}
 }
+
+// WithExtraInputFields merges extra input fields, can be called multiple times
+func WithExtraInputFields(extra ExtraInputFields) Option {
+	return func(c *Config) {
+		if extra == nil || len(extra) <= 0 {
+			return
+		}
+		if c.extraInputFields == nil {
+			c.extraInputFields = ExtraInputFields{}
+		}
+		for key, val := range extra {
+			c.extraInputFields[key] = val
+		}
+	}
+}
+
+// WithExtraInputField merges extra input field, can be called multiple times
+func WithExtraInputField(name string, value interface{}) Option {
+	return WithExtraInputFields(ExtraInputFields{name: value})
+}


### PR DESCRIPTION
Enhancement to support adding input data to OPA request input document without having to always update middleware.

```
atlas-authz-middleware$ make test
go vet ./...
go test ./...
?       github.com/infobloxopen/atlas-authz-middleware/cmd/authz_mw_cli [no test files]
ok      github.com/infobloxopen/atlas-authz-middleware/grpc_opa 0.104s
ok      github.com/infobloxopen/atlas-authz-middleware/pkg/opa_client   0.028s
?       github.com/infobloxopen/atlas-authz-middleware/utils_test       [no test files]
```