### PR TITLE
PTOCP-1121 - Update authz middleware to not redact the JWT token

### DIFF
--- a/http_opa/authorizer.go
+++ b/http_opa/authorizer.go
@@ -109,7 +109,7 @@ func (a *httpAuthorizer) Evaluate(ctx context.Context, endpoint string, req inte
 		Endpoint:         pargsEndpoint,
 		FullMethod:       endpoint,
 		Application:      a.application,
-		JWT:              opautil.RedactJWT(rawJWT),
+		JWT:              rawJWT,
 		RequestID:        reqID,
 		EntitledServices: a.entitledServices,
 	}


### PR DESCRIPTION
Update authz middleware not to redact the JWT token. The JWT validation needs a complete JWT token instead of the redacted one in the OPA container.