### PR TITLE
PTOCP-4598: Add new methods to get account metadata from opa bundle

### DIFF
--- a/grpc_opa/account_metadata.go
+++ b/grpc_opa/account_metadata.go
@@ -1,0 +1,184 @@
+package grpc_opa_middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	logrus "github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultAccountMetadataApiPath is default OPA path to fetch account metadata
+	DefaultAccountMetadataApiPath = "v1/data/authz/rbac/get_account_metadata_api"
+
+	// DefaultParentCspIdApiPath is default OPA path to resolve sandbox → parent CSP ID
+	DefaultParentCspIdApiPath = "v1/data/authz/rbac/get_parent_csp_id_api"
+
+	// DefaultCspBySfdcApiPath is default OPA path to resolve SFDC → CSP ID
+	DefaultCspBySfdcApiPath = "v1/data/authz/rbac/get_csp_by_sfdc_api"
+
+	// DefaultSandboxesForParentApiPath is default OPA path to fetch sandbox CSP IDs for a parent
+	DefaultSandboxesForParentApiPath = "v1/data/authz/rbac/get_sandboxes_for_parent_api"
+)
+
+// AccountMetadataApiInput is the input payload for get_account_metadata_api
+// and get_parent_csp_id_api (both use account_id as input key)
+type AccountMetadataApiInput struct {
+	AccountID string `json:"account_id"`
+}
+
+// SfdcApiInput is the input payload for get_csp_by_sfdc_api
+type SfdcApiInput struct {
+	SFDCAccountID string `json:"sfdc_account_id"`
+}
+
+// ParentApiInput is the input payload for get_sandboxes_for_parent_api
+type ParentApiInput struct {
+	ParentAccountID string `json:"parent_account_id"`
+}
+
+// AccountMetadataResult is the account metadata returned from OPA
+type AccountMetadataResult struct {
+	IdentityID      string `json:"identity_id"`
+	CspID           int64  `json:"csp_id"`
+	SfdcAccountID   string `json:"sfdc_account_id"`
+	AccountType     string `json:"account_type"`
+	ParentAccountID string `json:"parent_account_id"`
+	ParentCspID     int64  `json:"parent_csp_id"`
+	State           string `json:"state"`
+}
+
+// AccountMetadataApiResult wraps the OPA response for get_account_metadata_api
+type AccountMetadataApiResult struct {
+	Result *AccountMetadataResult `json:"result"`
+}
+
+// ParentCspIdApiResult wraps the OPA response for get_parent_csp_id_api
+type ParentCspIdApiResult struct {
+	Result *int64 `json:"result"`
+}
+
+// CspBySfdcApiResult wraps the OPA response for get_csp_by_sfdc_api
+type CspBySfdcApiResult struct {
+	Result *int64 `json:"result"`
+}
+
+// SandboxesForParentApiResult wraps the OPA response for get_sandboxes_for_parent_api
+type SandboxesForParentApiResult struct {
+	Result []int64 `json:"result"`
+}
+
+// GetAccountMetadata queries OPA sidecar for account metadata by CSP account ID.
+// Returns nil result (not error) if the account is not found in the OPA bundle data.
+func (a *DefaultAuthorizer) GetAccountMetadata(ctx context.Context, accountID string) (*AccountMetadataResult, error) {
+	lgNtry := ctxlogrus.Extract(ctx)
+
+	opaReq := OPARequest{
+		Input: &AccountMetadataApiInput{
+			AccountID: accountID,
+		},
+	}
+
+	var apiResult AccountMetadataApiResult
+	err := a.clienter.CustomQuery(ctx, a.accountMetadataApi, opaReq, &apiResult)
+	if err != nil {
+		lgNtry.WithError(err).Error("get_account_metadata_fail")
+		return nil, err
+	}
+
+	lgNtry.WithFields(logrus.Fields{
+		"account_id": accountID,
+		"result":     fmt.Sprintf("%+v", apiResult.Result),
+	}).Trace("get_account_metadata_okay")
+
+	return apiResult.Result, nil
+}
+
+// GetParentCspId queries OPA sidecar for the parent CSP ID of a sandbox account.
+// Returns 0 and nil error if the account is not a sandbox or not found.
+func (a *DefaultAuthorizer) GetParentCspId(ctx context.Context, sandboxCspID string) (int64, error) {
+	lgNtry := ctxlogrus.Extract(ctx)
+
+	opaReq := OPARequest{
+		Input: &AccountMetadataApiInput{
+			AccountID: sandboxCspID,
+		},
+	}
+
+	var apiResult ParentCspIdApiResult
+	err := a.clienter.CustomQuery(ctx, a.parentCspIdApi, opaReq, &apiResult)
+	if err != nil {
+		lgNtry.WithError(err).Error("get_parent_csp_id_fail")
+		return 0, err
+	}
+
+	var parentID int64
+	if apiResult.Result != nil {
+		parentID = *apiResult.Result
+	}
+
+	lgNtry.WithFields(logrus.Fields{
+		"sandbox_csp_id": sandboxCspID,
+		"parent_csp_id":  parentID,
+	}).Trace("get_parent_csp_id_okay")
+
+	return parentID, nil
+}
+
+// GetCspBySfdc queries OPA sidecar for CSP account ID by SFDC account ID.
+// Returns 0 and nil error if the SFDC account is not found.
+func (a *DefaultAuthorizer) GetCspBySfdc(ctx context.Context, sfdcAccountID string) (int64, error) {
+	lgNtry := ctxlogrus.Extract(ctx)
+
+	opaReq := OPARequest{
+		Input: &SfdcApiInput{
+			SFDCAccountID: sfdcAccountID,
+		},
+	}
+
+	var apiResult CspBySfdcApiResult
+	err := a.clienter.CustomQuery(ctx, a.cspBySfdcApi, opaReq, &apiResult)
+	if err != nil {
+		lgNtry.WithError(err).Error("get_csp_by_sfdc_fail")
+		return 0, err
+	}
+
+	var cspID int64
+	if apiResult.Result != nil {
+		cspID = *apiResult.Result
+	}
+
+	lgNtry.WithFields(logrus.Fields{
+		"sfdc_account_id": sfdcAccountID,
+		"csp_id":          cspID,
+	}).Trace("get_csp_by_sfdc_okay")
+
+	return cspID, nil
+}
+
+// GetSandboxesForParent queries OPA sidecar for all sandbox CSP IDs belonging to a parent.
+// Returns nil (not error) if the parent has no sandboxes or is not found.
+func (a *DefaultAuthorizer) GetSandboxesForParent(ctx context.Context, parentCspID string) ([]int64, error) {
+	lgNtry := ctxlogrus.Extract(ctx)
+
+	opaReq := OPARequest{
+		Input: &ParentApiInput{
+			ParentAccountID: parentCspID,
+		},
+	}
+
+	var apiResult SandboxesForParentApiResult
+	err := a.clienter.CustomQuery(ctx, a.sandboxesForParentApi, opaReq, &apiResult)
+	if err != nil {
+		lgNtry.WithError(err).Error("get_sandboxes_for_parent_fail")
+		return nil, err
+	}
+
+	lgNtry.WithFields(logrus.Fields{
+		"parent_csp_id": parentCspID,
+		"sandbox_ids":   apiResult.Result,
+	}).Trace("get_sandboxes_for_parent_okay")
+
+	return apiResult.Result, nil
+}

--- a/grpc_opa/account_metadata.go
+++ b/grpc_opa/account_metadata.go
@@ -23,9 +23,9 @@ const (
 )
 
 // AccountMetadataApiInput is the input payload for get_account_metadata_api
-// and get_parent_csp_id_api (both use account_id as input key)
+// and get_parent_csp_id_api (both use csp_account_id as input key)
 type AccountMetadataApiInput struct {
-	AccountID string `json:"account_id"`
+	AccountID string `json:"csp_account_id"`
 }
 
 // SfdcApiInput is the input payload for get_csp_by_sfdc_api
@@ -35,17 +35,19 @@ type SfdcApiInput struct {
 
 // ParentApiInput is the input payload for get_sandboxes_for_parent_api
 type ParentApiInput struct {
-	ParentAccountID string `json:"parent_account_id"`
+	ParentAccountID string `json:"parent_csp_id"`
 }
 
-// AccountMetadataResult is the account metadata returned from OPA
+// AccountMetadataResult is the account metadata returned from OPA.
+// Deprecated: Use AccountDetails from account_metadata_provider.go for new code.
+// This type is retained for backward compatibility with existing consumers.
 type AccountMetadataResult struct {
 	IdentityID      string `json:"identity_id"`
-	CspID           int64  `json:"csp_id"`
+	CspID           string `json:"csp_id"`
 	SfdcAccountID   string `json:"sfdc_account_id"`
 	AccountType     string `json:"account_type"`
 	ParentAccountID string `json:"parent_account_id"`
-	ParentCspID     int64  `json:"parent_csp_id"`
+	ParentCspID     string `json:"parent_csp_id"`
 	State           string `json:"state"`
 }
 
@@ -56,17 +58,17 @@ type AccountMetadataApiResult struct {
 
 // ParentCspIdApiResult wraps the OPA response for get_parent_csp_id_api
 type ParentCspIdApiResult struct {
-	Result *int64 `json:"result"`
+	Result *string `json:"result"`
 }
 
 // CspBySfdcApiResult wraps the OPA response for get_csp_by_sfdc_api
 type CspBySfdcApiResult struct {
-	Result *int64 `json:"result"`
+	Result *string `json:"result"`
 }
 
 // SandboxesForParentApiResult wraps the OPA response for get_sandboxes_for_parent_api
 type SandboxesForParentApiResult struct {
-	Result []int64 `json:"result"`
+	Result []string `json:"result"`
 }
 
 // GetAccountMetadata queries OPA sidecar for account metadata by CSP account ID.
@@ -96,8 +98,8 @@ func (a *DefaultAuthorizer) GetAccountMetadata(ctx context.Context, accountID st
 }
 
 // GetParentCspId queries OPA sidecar for the parent CSP ID of a sandbox account.
-// Returns 0 and nil error if the account is not a sandbox or not found.
-func (a *DefaultAuthorizer) GetParentCspId(ctx context.Context, sandboxCspID string) (int64, error) {
+// Returns "" and nil error if the account is not a sandbox or not found.
+func (a *DefaultAuthorizer) GetParentCspId(ctx context.Context, sandboxCspID string) (string, error) {
 	lgNtry := ctxlogrus.Extract(ctx)
 
 	opaReq := OPARequest{
@@ -110,10 +112,10 @@ func (a *DefaultAuthorizer) GetParentCspId(ctx context.Context, sandboxCspID str
 	err := a.clienter.CustomQuery(ctx, a.parentCspIdApi, opaReq, &apiResult)
 	if err != nil {
 		lgNtry.WithError(err).Error("get_parent_csp_id_fail")
-		return 0, err
+		return "", err
 	}
 
-	var parentID int64
+	var parentID string
 	if apiResult.Result != nil {
 		parentID = *apiResult.Result
 	}
@@ -127,8 +129,8 @@ func (a *DefaultAuthorizer) GetParentCspId(ctx context.Context, sandboxCspID str
 }
 
 // GetCspBySfdc queries OPA sidecar for CSP account ID by SFDC account ID.
-// Returns 0 and nil error if the SFDC account is not found.
-func (a *DefaultAuthorizer) GetCspBySfdc(ctx context.Context, sfdcAccountID string) (int64, error) {
+// Returns "" and nil error if the SFDC account is not found.
+func (a *DefaultAuthorizer) GetCspBySfdc(ctx context.Context, sfdcAccountID string) (string, error) {
 	lgNtry := ctxlogrus.Extract(ctx)
 
 	opaReq := OPARequest{
@@ -141,10 +143,10 @@ func (a *DefaultAuthorizer) GetCspBySfdc(ctx context.Context, sfdcAccountID stri
 	err := a.clienter.CustomQuery(ctx, a.cspBySfdcApi, opaReq, &apiResult)
 	if err != nil {
 		lgNtry.WithError(err).Error("get_csp_by_sfdc_fail")
-		return 0, err
+		return "", err
 	}
 
-	var cspID int64
+	var cspID string
 	if apiResult.Result != nil {
 		cspID = *apiResult.Result
 	}
@@ -159,7 +161,7 @@ func (a *DefaultAuthorizer) GetCspBySfdc(ctx context.Context, sfdcAccountID stri
 
 // GetSandboxesForParent queries OPA sidecar for all sandbox CSP IDs belonging to a parent.
 // Returns nil (not error) if the parent has no sandboxes or is not found.
-func (a *DefaultAuthorizer) GetSandboxesForParent(ctx context.Context, parentCspID string) ([]int64, error) {
+func (a *DefaultAuthorizer) GetSandboxesForParent(ctx context.Context, parentCspID string) ([]string, error) {
 	lgNtry := ctxlogrus.Extract(ctx)
 
 	opaReq := OPARequest{

--- a/grpc_opa/account_metadata_provider.go
+++ b/grpc_opa/account_metadata_provider.go
@@ -1,0 +1,220 @@
+package grpc_opa_middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	logrus "github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultAcctEntitlementsFilteredApiPath is the OPA path for the enriched
+	// acct_entitlements_filtered_api that returns entitlements + account_details +
+	// resolved_account_id per account in a single call.
+	// Sandbox-parent resolution is built into this rule: when
+	// authz_settings.sandbox_parent_entitlement_enabled is true, ResolvedAccountID
+	// is the PARENT's CSP ID for STATE-1 sandbox accounts. Consumers must use
+	// ResolvedAccountID for license/entitlement lookups so that after mirroring is
+	// disabled, reads automatically redirect to the parent without any code change.
+	DefaultAcctEntitlementsFilteredApiPath = "v1/data/authz/rbac/acct_entitlements_filtered_api"
+
+	// DefaultAccountMetadataBySfdcApiPath is the OPA path for the combined
+	// SFDC-account-ID → full account metadata lookup (single call).
+	DefaultAccountMetadataBySfdcApiPath = "v1/data/authz/rbac/get_account_metadata_by_sfdc_api"
+)
+
+// AccountDetails holds account metadata as stored in the OPA bundle.
+// All ID fields (CspID, ParentCspID) are strings to match the OPA data format —
+// the account-metadata-publisher stores them as decimal strings, not JSON numbers.
+type AccountDetails struct {
+	IdentityID      string `json:"identity_id"`
+	CspID           string `json:"csp_id"`
+	SfdcAccountID   string `json:"sfdc_account_id"`
+	AccountType     string `json:"account_type"`
+	ParentAccountID string `json:"parent_account_id"`
+	// ParentCspID is the pre-resolved CSP ID of the parent account.
+	// Populated by the account-metadata-publisher; eliminates a second Identity
+	// API call for sandbox parent lookups.
+	ParentCspID string `json:"parent_csp_id"`
+	State       string `json:"state"`
+}
+
+// AcctEntitlementEnrichedEntry is the per-account entry returned by
+// acct_entitlements_filtered_api. It combines entitlements, account details,
+// and the resolved account ID in a single OPA call.
+//
+// ResolvedAccountID is the account ID that entitlements were read from:
+//   - For STATE-1 sandbox accounts (sandbox_parent_entitlement_enabled=true):
+//     this is the PARENT's CSP ID.
+//   - For all other accounts: this equals the account's own CSP ID.
+//
+// Consumers MUST use ResolvedAccountID for license/entitlement lookups.
+// This ensures that after mirroring is disabled, existing consumers
+// automatically redirect reads to the parent without any code change.
+type AcctEntitlementEnrichedEntry struct {
+	Entitlements      map[string][]string `json:"entitlements"`
+	AccountDetails    *AccountDetails     `json:"account_details"`
+	ResolvedAccountID string              `json:"resolved_account_id"`
+}
+
+// AccountMetadataProvider is the interface for looking up account metadata
+// from the OPA sidecar bundle. All methods return nil result (not error) when
+// the account/SFDC ID is absent from the bundle — the caller is responsible
+// for treating nil as a cache miss and falling back to the Identity API.
+//
+// DefaultAuthorizer implements this interface. Services that only need metadata
+// lookups (not full authz interception) can construct a DefaultAuthorizer via
+// NewDefaultAuthorizer("") and use it solely as AccountMetadataProvider.
+type AccountMetadataProvider interface {
+	// GetAccountDetails returns account details for the given CSP account ID
+	// by querying acct_entitlements_filtered_api. Sandbox-parent resolution is
+	// applied transparently via ResolvedAccountID.
+	GetAccountDetails(ctx context.Context, cspAccountID string) (*AccountDetails, error)
+
+	// GetEnrichedAccountMetadata returns the full enriched entry
+	// (entitlements + account_details + resolved_account_id) for the given CSP
+	// account ID. Use ResolvedAccountID from the result for all downstream lookups.
+	GetEnrichedAccountMetadata(ctx context.Context, cspAccountID string) (*AcctEntitlementEnrichedEntry, error)
+
+	// GetAccountDetailsBySfdc returns full account details for the given SFDC ID
+	// in a single OPA call, combining the SFDC→CSP and CSP→metadata lookups.
+	GetAccountDetailsBySfdc(ctx context.Context, sfdcID string) (*AccountDetails, error)
+
+	// GetCspBySfdcID resolves a SFDC account ID to a CSP account ID (string).
+	// Returns ("", nil) when the SFDC ID is not present in the OPA bundle.
+	GetCspBySfdcID(ctx context.Context, sfdcID string) (string, error)
+}
+
+// --- internal request/response types ---
+
+// acctEntitlementsFilteredInput is the input for acct_entitlements_filtered_api.
+type acctEntitlementsFilteredInput struct {
+	AccountIDs   []string `json:"acct_entitlements_acct_ids"`
+	ServiceNames []string `json:"acct_entitlements_services"`
+}
+
+// acctEntitlementsFilteredResult is the OPA response wrapper.
+// Result is a map of csp_account_id → AcctEntitlementEnrichedEntry.
+type acctEntitlementsFilteredResult struct {
+	Result map[string]*AcctEntitlementEnrichedEntry `json:"result"`
+}
+
+// sfdcIDInput is the input for get_csp_by_sfdc_api and get_account_metadata_by_sfdc_api.
+type sfdcIDInput struct {
+	SfdcAccountID string `json:"sfdc_account_id"`
+}
+
+// cspBySfdcStringResult wraps the OPA response for get_csp_by_sfdc_api.
+// The result is a string CSP ID (not int64) matching the OPA bundle format.
+type cspBySfdcStringResult struct {
+	Result *string `json:"result"`
+}
+
+// accountDetailsBySfdcResult wraps the OPA response for get_account_metadata_by_sfdc_api.
+type accountDetailsBySfdcResult struct {
+	Result *AccountDetails `json:"result"`
+}
+
+// GetEnrichedAccountMetadata queries acct_entitlements_filtered_api for the given
+// CSP account ID and returns the full enriched entry including ResolvedAccountID.
+// Returns nil (not error) if the account is not in the OPA bundle.
+func (a *DefaultAuthorizer) GetEnrichedAccountMetadata(ctx context.Context, cspAccountID string) (*AcctEntitlementEnrichedEntry, error) {
+	lgNtry := ctxlogrus.Extract(ctx)
+
+	opaReq := OPARequest{
+		Input: &acctEntitlementsFilteredInput{
+			AccountIDs:   []string{cspAccountID},
+			ServiceNames: []string{}, // empty = all services
+		},
+	}
+
+	var apiResult acctEntitlementsFilteredResult
+	if err := a.clienter.CustomQuery(ctx, a.acctEntitlementsFilteredApi, opaReq, &apiResult); err != nil {
+		lgNtry.WithError(err).Error("get_enriched_account_metadata_fail")
+		return nil, fmt.Errorf("get_enriched_account_metadata: %w", err)
+	}
+
+	entry, found := apiResult.Result[cspAccountID]
+	if !found || entry == nil {
+		lgNtry.WithField("csp_account_id", cspAccountID).Debug("enriched_account_metadata_not_found")
+		return nil, nil
+	}
+
+	lgNtry.WithFields(logrus.Fields{
+		"csp_account_id":      cspAccountID,
+		"resolved_account_id": entry.ResolvedAccountID,
+	}).Trace("get_enriched_account_metadata_okay")
+
+	return entry, nil
+}
+
+// GetAccountDetails returns account details for the given CSP account ID
+// using acct_entitlements_filtered_api. Returns nil (not error) if absent.
+func (a *DefaultAuthorizer) GetAccountDetails(ctx context.Context, cspAccountID string) (*AccountDetails, error) {
+	entry, err := a.GetEnrichedAccountMetadata(ctx, cspAccountID)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	if entry.AccountDetails == nil || entry.AccountDetails.CspID == "" {
+		return nil, nil
+	}
+	return entry.AccountDetails, nil
+}
+
+// GetAccountDetailsBySfdc queries get_account_metadata_by_sfdc_api to resolve a
+// SFDC account ID directly to full account details in a single OPA call.
+// Returns nil (not error) if the SFDC ID is not in the OPA bundle.
+func (a *DefaultAuthorizer) GetAccountDetailsBySfdc(ctx context.Context, sfdcID string) (*AccountDetails, error) {
+	lgNtry := ctxlogrus.Extract(ctx)
+
+	opaReq := OPARequest{
+		Input: &sfdcIDInput{SfdcAccountID: sfdcID},
+	}
+
+	var apiResult accountDetailsBySfdcResult
+	if err := a.clienter.CustomQuery(ctx, a.accountMetadataBySfdcApi, opaReq, &apiResult); err != nil {
+		lgNtry.WithError(err).Error("get_account_details_by_sfdc_fail")
+		return nil, fmt.Errorf("get_account_details_by_sfdc: %w", err)
+	}
+
+	lgNtry.WithFields(logrus.Fields{
+		"sfdc_id": sfdcID,
+		"result":  fmt.Sprintf("%+v", apiResult.Result),
+	}).Trace("get_account_details_by_sfdc_okay")
+
+	return apiResult.Result, nil
+}
+
+// GetCspBySfdcID resolves a SFDC account ID to a CSP account ID (string).
+// Returns ("", nil) if the SFDC ID is not in the OPA bundle.
+func (a *DefaultAuthorizer) GetCspBySfdcID(ctx context.Context, sfdcID string) (string, error) {
+	lgNtry := ctxlogrus.Extract(ctx)
+
+	opaReq := OPARequest{
+		Input: &sfdcIDInput{SfdcAccountID: sfdcID},
+	}
+
+	var apiResult cspBySfdcStringResult
+	if err := a.clienter.CustomQuery(ctx, a.cspBySfdcApi, opaReq, &apiResult); err != nil {
+		lgNtry.WithError(err).Error("get_csp_by_sfdc_id_fail")
+		return "", fmt.Errorf("get_csp_by_sfdc_id: %w", err)
+	}
+
+	if apiResult.Result == nil {
+		lgNtry.WithField("sfdc_id", sfdcID).Debug("csp_by_sfdc_id_not_found")
+		return "", nil
+	}
+
+	lgNtry.WithFields(logrus.Fields{
+		"sfdc_id": sfdcID,
+		"csp_id":  *apiResult.Result,
+	}).Trace("get_csp_by_sfdc_id_okay")
+
+	return *apiResult.Result, nil
+}
+
+

--- a/grpc_opa/account_metadata_provider_test.go
+++ b/grpc_opa/account_metadata_provider_test.go
@@ -5,9 +5,20 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/infobloxopen/atlas-authz-middleware/utils_test"
+
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	logrus "github.com/sirupsen/logrus"
 )
+
+// newTestContext creates a context with the testing.T propagated for mock-internal
+// logging, matching the pattern in account_metadata_test.go.
+func newTestContext(t *testing.T) context.Context {
+	t.Helper()
+	stdLoggr := logrus.StandardLogger()
+	ctx := context.WithValue(context.Background(), utils_test.TestingTContextKey, t)
+	return ctxlogrus.ToContext(ctx, logrus.NewEntry(stdLoggr))
+}
 
 func TestGetEnrichedAccountMetadataMockOpaClient(t *testing.T) {
 	testMap := []struct {
@@ -142,7 +153,7 @@ func TestGetEnrichedAccountMetadataMockOpaClient(t *testing.T) {
 	}
 
 	stdLoggr := logrus.StandardLogger()
-	ctx := ctxlogrus.ToContext(context.Background(), logrus.NewEntry(stdLoggr))
+	ctx := newTestContext(t)
 
 	for nth, tm := range testMap {
 		t.Run(tm.name, func(t *testing.T) {
@@ -298,7 +309,7 @@ func TestGetAccountDetailsMockOpaClient(t *testing.T) {
 	}
 
 	stdLoggr := logrus.StandardLogger()
-	ctx := ctxlogrus.ToContext(context.Background(), logrus.NewEntry(stdLoggr))
+	ctx := newTestContext(t)
 
 	for nth, tm := range testMap {
 		t.Run(tm.name, func(t *testing.T) {
@@ -380,7 +391,7 @@ func TestGetAccountDetailsBySfdcMockOpaClient(t *testing.T) {
 	}
 
 	stdLoggr := logrus.StandardLogger()
-	ctx := ctxlogrus.ToContext(context.Background(), logrus.NewEntry(stdLoggr))
+	ctx := newTestContext(t)
 
 	for nth, tm := range testMap {
 		t.Run(tm.name, func(t *testing.T) {
@@ -451,7 +462,7 @@ func TestGetCspBySfdcIDMockOpaClient(t *testing.T) {
 	}
 
 	stdLoggr := logrus.StandardLogger()
-	ctx := ctxlogrus.ToContext(context.Background(), logrus.NewEntry(stdLoggr))
+	ctx := newTestContext(t)
 
 	for nth, tm := range testMap {
 		t.Run(tm.name, func(t *testing.T) {
@@ -478,4 +489,3 @@ func TestGetCspBySfdcIDMockOpaClient(t *testing.T) {
 		})
 	}
 }
-

--- a/grpc_opa/account_metadata_provider_test.go
+++ b/grpc_opa/account_metadata_provider_test.go
@@ -1,0 +1,481 @@
+package grpc_opa_middleware
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	logrus "github.com/sirupsen/logrus"
+)
+
+func TestGetEnrichedAccountMetadataMockOpaClient(t *testing.T) {
+	testMap := []struct {
+		name        string
+		accountID   string
+		regoJSON    string
+		expectErr   bool
+		expectedVal *AcctEntitlementEnrichedEntry
+	}{
+		{
+			name:      "sandbox account with parent and entitlements",
+			accountID: "200",
+			regoJSON: `{
+				"result": {
+					"200": {
+						"entitlements": {
+							"license": ["feature_a", "feature_b"]
+						},
+						"account_details": {
+							"identity_id": "f0e1d2c3-b4a5-6789-0fed-cba987654321",
+							"csp_id": "200",
+							"sfdc_account_id": "",
+							"account_type": "sandbox",
+							"parent_account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+							"parent_csp_id": "100",
+							"state": "active"
+						},
+						"resolved_account_id": "100"
+					}
+				}
+			}`,
+			expectErr: false,
+			expectedVal: &AcctEntitlementEnrichedEntry{
+				Entitlements: map[string][]string{
+					"license": {"feature_a", "feature_b"},
+				},
+				AccountDetails: &AccountDetails{
+					IdentityID:      "f0e1d2c3-b4a5-6789-0fed-cba987654321",
+					CspID:           "200",
+					SfdcAccountID:   "",
+					AccountType:     "sandbox",
+					ParentAccountID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+					ParentCspID:     "100",
+					State:           "active",
+				},
+				ResolvedAccountID: "100",
+			},
+		},
+		{
+			name:      "regular account resolves to itself",
+			accountID: "100",
+			regoJSON: `{
+				"result": {
+					"100": {
+						"entitlements": {
+							"license": ["feature_x"]
+						},
+						"account_details": {
+							"identity_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+							"csp_id": "100",
+							"sfdc_account_id": "001ABC000XYZ123",
+							"account_type": "regular",
+							"parent_account_id": "",
+							"parent_csp_id": "",
+							"state": "active"
+						},
+						"resolved_account_id": "100"
+					}
+				}
+			}`,
+			expectErr: false,
+			expectedVal: &AcctEntitlementEnrichedEntry{
+				Entitlements: map[string][]string{
+					"license": {"feature_x"},
+				},
+				AccountDetails: &AccountDetails{
+					IdentityID:      "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+					CspID:           "100",
+					SfdcAccountID:   "001ABC000XYZ123",
+					AccountType:     "regular",
+					ParentAccountID: "",
+					ParentCspID:     "",
+					State:           "active",
+				},
+				ResolvedAccountID: "100",
+			},
+		},
+		{
+			name:      "account with entitlements but missing from account_metadata (empty account_details)",
+			accountID: "264",
+			regoJSON: `{
+				"result": {
+					"264": {
+						"entitlements": {
+							"license": ["some_feature"]
+						},
+						"account_details": {},
+						"resolved_account_id": "264"
+					}
+				}
+			}`,
+			expectErr: false,
+			expectedVal: &AcctEntitlementEnrichedEntry{
+				Entitlements: map[string][]string{
+					"license": {"some_feature"},
+				},
+				AccountDetails:    &AccountDetails{},
+				ResolvedAccountID: "264",
+			},
+		},
+		{
+			name:        "account not found returns nil",
+			accountID:   "999",
+			regoJSON:    `{"result": {}}`,
+			expectErr:   false,
+			expectedVal: nil,
+		},
+		{
+			name:        "null result returns nil",
+			accountID:   "999",
+			regoJSON:    `{"result": null}`,
+			expectErr:   false,
+			expectedVal: nil,
+		},
+		{
+			name:        "invalid json returns error",
+			accountID:   "200",
+			regoJSON:    `[null]`,
+			expectErr:   true,
+			expectedVal: nil,
+		},
+	}
+
+	stdLoggr := logrus.StandardLogger()
+	ctx := ctxlogrus.ToContext(context.Background(), logrus.NewEntry(stdLoggr))
+
+	for nth, tm := range testMap {
+		t.Run(tm.name, func(t *testing.T) {
+			mockOpaClienter := MockOpaClienter{
+				Loggr:        stdLoggr,
+				RegoRespJSON: tm.regoJSON,
+			}
+			auther := NewDefaultAuthorizer("bogus_unused_application_value",
+				WithOpaClienter(&mockOpaClienter),
+			)
+
+			actualVal, actualErr := auther.GetEnrichedAccountMetadata(ctx, tm.accountID)
+			t.Logf("%d: %q: actualErr=%v, actualVal=%+v", nth, tm.name, actualErr, actualVal)
+
+			if tm.expectErr && actualErr == nil {
+				t.Errorf("expected err, but got no err")
+			} else if !tm.expectErr && actualErr != nil {
+				t.Errorf("got unexpected err=%s", actualErr)
+			}
+
+			if actualErr != nil && actualVal != nil {
+				t.Errorf("returned val should be nil if err returned")
+			}
+
+			if !reflect.DeepEqual(actualVal, tm.expectedVal) {
+				t.Errorf("expectedVal=%+v actualVal=%+v", tm.expectedVal, actualVal)
+			}
+		})
+	}
+}
+
+func TestGetAccountDetailsMockOpaClient(t *testing.T) {
+	testMap := []struct {
+		name        string
+		accountID   string
+		regoJSON    string
+		expectErr   bool
+		expectedVal *AccountDetails
+	}{
+		{
+			name:      "sandbox account returns details",
+			accountID: "200",
+			regoJSON: `{
+				"result": {
+					"200": {
+						"entitlements": {"license": ["feat"]},
+						"account_details": {
+							"identity_id": "f0e1d2c3-b4a5-6789-0fed-cba987654321",
+							"csp_id": "200",
+							"sfdc_account_id": "",
+							"account_type": "sandbox",
+							"parent_account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+							"parent_csp_id": "100",
+							"state": "active"
+						},
+						"resolved_account_id": "100"
+					}
+				}
+			}`,
+			expectErr: false,
+			expectedVal: &AccountDetails{
+				IdentityID:      "f0e1d2c3-b4a5-6789-0fed-cba987654321",
+				CspID:           "200",
+				SfdcAccountID:   "",
+				AccountType:     "sandbox",
+				ParentAccountID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+				ParentCspID:     "100",
+				State:           "active",
+			},
+		},
+		{
+			name:      "regular account returns details",
+			accountID: "100",
+			regoJSON: `{
+				"result": {
+					"100": {
+						"entitlements": {"license": ["feat"]},
+						"account_details": {
+							"identity_id": "a1b2c3d4",
+							"csp_id": "100",
+							"sfdc_account_id": "001ABC",
+							"account_type": "regular",
+							"parent_account_id": "",
+							"parent_csp_id": "",
+							"state": "active"
+						},
+						"resolved_account_id": "100"
+					}
+				}
+			}`,
+			expectErr: false,
+			expectedVal: &AccountDetails{
+				IdentityID:      "a1b2c3d4",
+				CspID:           "100",
+				SfdcAccountID:   "001ABC",
+				AccountType:     "regular",
+				ParentAccountID: "",
+				ParentCspID:     "",
+				State:           "active",
+			},
+		},
+		{
+			name:      "empty account_details (missing from account_metadata) returns nil - CspID empty",
+			accountID: "264",
+			regoJSON: `{
+				"result": {
+					"264": {
+						"entitlements": {"license": ["some_feature"]},
+						"account_details": {},
+						"resolved_account_id": "264"
+					}
+				}
+			}`,
+			expectErr:   false,
+			expectedVal: nil,
+		},
+		{
+			name:      "null account_details returns nil",
+			accountID: "300",
+			regoJSON: `{
+				"result": {
+					"300": {
+						"entitlements": {"license": ["feat"]},
+						"account_details": null,
+						"resolved_account_id": "300"
+					}
+				}
+			}`,
+			expectErr:   false,
+			expectedVal: nil,
+		},
+		{
+			name:        "account not found in result returns nil",
+			accountID:   "999",
+			regoJSON:    `{"result": {}}`,
+			expectErr:   false,
+			expectedVal: nil,
+		},
+		{
+			name:        "null result returns nil",
+			accountID:   "999",
+			regoJSON:    `{"result": null}`,
+			expectErr:   false,
+			expectedVal: nil,
+		},
+		{
+			name:        "invalid json returns error",
+			accountID:   "200",
+			regoJSON:    `[null]`,
+			expectErr:   true,
+			expectedVal: nil,
+		},
+	}
+
+	stdLoggr := logrus.StandardLogger()
+	ctx := ctxlogrus.ToContext(context.Background(), logrus.NewEntry(stdLoggr))
+
+	for nth, tm := range testMap {
+		t.Run(tm.name, func(t *testing.T) {
+			mockOpaClienter := MockOpaClienter{
+				Loggr:        stdLoggr,
+				RegoRespJSON: tm.regoJSON,
+			}
+			auther := NewDefaultAuthorizer("bogus_unused_application_value",
+				WithOpaClienter(&mockOpaClienter),
+			)
+
+			actualVal, actualErr := auther.GetAccountDetails(ctx, tm.accountID)
+			t.Logf("%d: %q: actualErr=%v, actualVal=%+v", nth, tm.name, actualErr, actualVal)
+
+			if tm.expectErr && actualErr == nil {
+				t.Errorf("expected err, but got no err")
+			} else if !tm.expectErr && actualErr != nil {
+				t.Errorf("got unexpected err=%s", actualErr)
+			}
+
+			if actualErr != nil && actualVal != nil {
+				t.Errorf("returned val should be nil if err returned")
+			}
+
+			if !reflect.DeepEqual(actualVal, tm.expectedVal) {
+				t.Errorf("expectedVal=%+v actualVal=%+v", tm.expectedVal, actualVal)
+			}
+		})
+	}
+}
+
+func TestGetAccountDetailsBySfdcMockOpaClient(t *testing.T) {
+	testMap := []struct {
+		name        string
+		sfdcID      string
+		regoJSON    string
+		expectErr   bool
+		expectedVal *AccountDetails
+	}{
+		{
+			name:   "valid sfdc returns account details",
+			sfdcID: "001ABC000XYZ123",
+			regoJSON: `{
+				"result": {
+					"identity_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+					"csp_id": "100",
+					"sfdc_account_id": "001ABC000XYZ123",
+					"account_type": "regular",
+					"parent_account_id": "",
+					"parent_csp_id": "",
+					"state": "active"
+				}
+			}`,
+			expectErr: false,
+			expectedVal: &AccountDetails{
+				IdentityID:      "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+				CspID:           "100",
+				SfdcAccountID:   "001ABC000XYZ123",
+				AccountType:     "regular",
+				ParentAccountID: "",
+				ParentCspID:     "",
+				State:           "active",
+			},
+		},
+		{
+			name:        "unknown sfdc returns nil",
+			sfdcID:      "001UNKNOWN",
+			regoJSON:    `{"result": null}`,
+			expectErr:   false,
+			expectedVal: nil,
+		},
+		{
+			name:        "invalid json returns error",
+			sfdcID:      "001ABC",
+			regoJSON:    `[null]`,
+			expectErr:   true,
+			expectedVal: nil,
+		},
+	}
+
+	stdLoggr := logrus.StandardLogger()
+	ctx := ctxlogrus.ToContext(context.Background(), logrus.NewEntry(stdLoggr))
+
+	for nth, tm := range testMap {
+		t.Run(tm.name, func(t *testing.T) {
+			mockOpaClienter := MockOpaClienter{
+				Loggr:        stdLoggr,
+				RegoRespJSON: tm.regoJSON,
+			}
+			auther := NewDefaultAuthorizer("bogus_unused_application_value",
+				WithOpaClienter(&mockOpaClienter),
+			)
+
+			actualVal, actualErr := auther.GetAccountDetailsBySfdc(ctx, tm.sfdcID)
+			t.Logf("%d: %q: actualErr=%v, actualVal=%+v", nth, tm.name, actualErr, actualVal)
+
+			if tm.expectErr && actualErr == nil {
+				t.Errorf("expected err, but got no err")
+			} else if !tm.expectErr && actualErr != nil {
+				t.Errorf("got unexpected err=%s", actualErr)
+			}
+
+			if actualErr != nil && actualVal != nil {
+				t.Errorf("returned val should be nil if err returned")
+			}
+
+			if !reflect.DeepEqual(actualVal, tm.expectedVal) {
+				t.Errorf("expectedVal=%+v actualVal=%+v", tm.expectedVal, actualVal)
+			}
+		})
+	}
+}
+
+func TestGetCspBySfdcIDMockOpaClient(t *testing.T) {
+	testMap := []struct {
+		name      string
+		sfdcID    string
+		regoJSON  string
+		expectErr bool
+		expectVal string
+	}{
+		{
+			name:      "valid sfdc returns csp id string",
+			sfdcID:    "001ABC000XYZ123",
+			regoJSON:  `{"result": "100"}`,
+			expectErr: false,
+			expectVal: "100",
+		},
+		{
+			name:      "unknown sfdc returns empty string",
+			sfdcID:    "001UNKNOWN",
+			regoJSON:  `{"result": null}`,
+			expectErr: false,
+			expectVal: "",
+		},
+		{
+			name:      "no result key returns empty string",
+			sfdcID:    "001ABC",
+			regoJSON:  `{}`,
+			expectErr: false,
+			expectVal: "",
+		},
+		{
+			name:      "invalid json returns error",
+			sfdcID:    "001ABC",
+			regoJSON:  `[null]`,
+			expectErr: true,
+			expectVal: "",
+		},
+	}
+
+	stdLoggr := logrus.StandardLogger()
+	ctx := ctxlogrus.ToContext(context.Background(), logrus.NewEntry(stdLoggr))
+
+	for nth, tm := range testMap {
+		t.Run(tm.name, func(t *testing.T) {
+			mockOpaClienter := MockOpaClienter{
+				Loggr:        stdLoggr,
+				RegoRespJSON: tm.regoJSON,
+			}
+			auther := NewDefaultAuthorizer("bogus_unused_application_value",
+				WithOpaClienter(&mockOpaClienter),
+			)
+
+			actualVal, actualErr := auther.GetCspBySfdcID(ctx, tm.sfdcID)
+			t.Logf("%d: %q: actualErr=%v, actualVal=%q", nth, tm.name, actualErr, actualVal)
+
+			if tm.expectErr && actualErr == nil {
+				t.Errorf("expected err, but got no err")
+			} else if !tm.expectErr && actualErr != nil {
+				t.Errorf("got unexpected err=%s", actualErr)
+			}
+
+			if actualVal != tm.expectVal {
+				t.Errorf("expectVal=%q actualVal=%q", tm.expectVal, actualVal)
+			}
+		})
+	}
+}
+

--- a/grpc_opa/account_metadata_test.go
+++ b/grpc_opa/account_metadata_test.go
@@ -1,0 +1,320 @@
+package grpc_opa_middleware
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/infobloxopen/atlas-authz-middleware/utils_test"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	logrus "github.com/sirupsen/logrus"
+)
+
+func TestGetAccountMetadataMockOpaClient(t *testing.T) {
+	testMap := []struct {
+		name        string
+		accountID   string
+		regoJSON    string
+		expectErr   bool
+		expectedVal *AccountMetadataResult
+	}{
+		{
+			name:      "sandbox account with parent",
+			accountID: "200",
+			regoJSON: `{
+				"result": {
+					"identity_id": "f0e1d2c3-b4a5-6789-0fed-cba987654321",
+					"csp_id": 200,
+					"sfdc_account_id": "",
+					"account_type": "sandbox",
+					"parent_account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+					"parent_csp_id": 100,
+					"state": "active"
+				}
+			}`,
+			expectErr: false,
+			expectedVal: &AccountMetadataResult{
+				IdentityID:      "f0e1d2c3-b4a5-6789-0fed-cba987654321",
+				CspID:           200,
+				SfdcAccountID:   "",
+				AccountType:     "sandbox",
+				ParentAccountID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+				ParentCspID:     100,
+				State:           "active",
+			},
+		},
+		{
+			name:      "regular account",
+			accountID: "100",
+			regoJSON: `{
+				"result": {
+					"identity_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+					"csp_id": 100,
+					"sfdc_account_id": "001ABC000XYZ123",
+					"account_type": "regular",
+					"parent_account_id": "",
+					"parent_csp_id": 0,
+					"state": "active"
+				}
+			}`,
+			expectErr: false,
+			expectedVal: &AccountMetadataResult{
+				IdentityID:      "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+				CspID:           100,
+				SfdcAccountID:   "001ABC000XYZ123",
+				AccountType:     "regular",
+				ParentAccountID: "",
+				ParentCspID:     0,
+				State:           "active",
+			},
+		},
+		{
+			name:        "account not found returns nil result",
+			accountID:   "999",
+			regoJSON:    `{"result": null}`,
+			expectErr:   false,
+			expectedVal: nil,
+		},
+		{
+			name:        "no result key returns nil result",
+			accountID:   "200",
+			regoJSON:    `{"rresult": null}`,
+			expectErr:   false,
+			expectedVal: nil,
+		},
+		{
+			name:        "invalid json returns error",
+			accountID:   "200",
+			regoJSON:    `[null]`,
+			expectErr:   true,
+			expectedVal: nil,
+		},
+	}
+
+	stdLoggr := logrus.StandardLogger()
+	ctx := context.WithValue(context.Background(), utils_test.TestingTContextKey, t)
+	ctx = ctxlogrus.ToContext(ctx, logrus.NewEntry(stdLoggr))
+
+	for nth, tm := range testMap {
+		mockOpaClienter := MockOpaClienter{
+			Loggr:        stdLoggr,
+			RegoRespJSON: tm.regoJSON,
+		}
+		auther := NewDefaultAuthorizer("bogus_unused_application_value",
+			WithOpaClienter(&mockOpaClienter),
+		)
+
+		actualVal, actualErr := auther.GetAccountMetadata(ctx, tm.accountID)
+		t.Logf("%d: %q: actualErr=%v, actualVal=%+v", nth, tm.name, actualErr, actualVal)
+
+		if tm.expectErr && actualErr == nil {
+			t.Errorf("%d: %q: FAIL: expected err, but got no err", nth, tm.name)
+		} else if !tm.expectErr && actualErr != nil {
+			t.Errorf("%d: %q: FAIL: got unexpected err=%s", nth, tm.name, actualErr)
+		}
+
+		if actualErr != nil && actualVal != nil {
+			t.Errorf("%d: %q: FAIL: returned val should be nil if err returned", nth, tm.name)
+		}
+
+		if !reflect.DeepEqual(actualVal, tm.expectedVal) {
+			t.Errorf("%d: %q: FAIL: expectedVal=%+v actualVal=%+v",
+				nth, tm.name, tm.expectedVal, actualVal)
+		}
+	}
+}
+
+func TestGetParentCspIdMockOpaClient(t *testing.T) {
+	testMap := []struct {
+		name      string
+		accountID string
+		regoJSON  string
+		expectErr bool
+		expectVal int64
+	}{
+		{
+			name:      "sandbox returns parent id",
+			accountID: "200",
+			regoJSON:  `{"result": 100}`,
+			expectErr: false,
+			expectVal: 100,
+		},
+		{
+			name:      "non-sandbox returns zero",
+			accountID: "100",
+			regoJSON:  `{"result": null}`,
+			expectErr: false,
+			expectVal: 0,
+		},
+		{
+			name:      "account not found returns zero",
+			accountID: "999",
+			regoJSON:  `{}`,
+			expectErr: false,
+			expectVal: 0,
+		},
+		{
+			name:      "invalid json returns error",
+			accountID: "200",
+			regoJSON:  `[null]`,
+			expectErr: true,
+			expectVal: 0,
+		},
+	}
+
+	stdLoggr := logrus.StandardLogger()
+	ctx := context.WithValue(context.Background(), utils_test.TestingTContextKey, t)
+	ctx = ctxlogrus.ToContext(ctx, logrus.NewEntry(stdLoggr))
+
+	for nth, tm := range testMap {
+		mockOpaClienter := MockOpaClienter{
+			Loggr:        stdLoggr,
+			RegoRespJSON: tm.regoJSON,
+		}
+		auther := NewDefaultAuthorizer("bogus_unused_application_value",
+			WithOpaClienter(&mockOpaClienter),
+		)
+
+		actualVal, actualErr := auther.GetParentCspId(ctx, tm.accountID)
+		t.Logf("%d: %q: actualErr=%v, actualVal=%d", nth, tm.name, actualErr, actualVal)
+
+		if tm.expectErr && actualErr == nil {
+			t.Errorf("%d: %q: FAIL: expected err, but got no err", nth, tm.name)
+		} else if !tm.expectErr && actualErr != nil {
+			t.Errorf("%d: %q: FAIL: got unexpected err=%s", nth, tm.name, actualErr)
+		}
+
+		if actualVal != tm.expectVal {
+			t.Errorf("%d: %q: FAIL: expectVal=%d actualVal=%d",
+				nth, tm.name, tm.expectVal, actualVal)
+		}
+	}
+}
+
+func TestGetCspBySfdcMockOpaClient(t *testing.T) {
+	testMap := []struct {
+		name      string
+		sfdcID    string
+		regoJSON  string
+		expectErr bool
+		expectVal int64
+	}{
+		{
+			name:      "valid sfdc returns csp id",
+			sfdcID:    "001ABC000XYZ123",
+			regoJSON:  `{"result": 100}`,
+			expectErr: false,
+			expectVal: 100,
+		},
+		{
+			name:      "unknown sfdc returns zero",
+			sfdcID:    "001UNKNOWN",
+			regoJSON:  `{"result": null}`,
+			expectErr: false,
+			expectVal: 0,
+		},
+		{
+			name:      "invalid json returns error",
+			sfdcID:    "001ABC",
+			regoJSON:  `[null]`,
+			expectErr: true,
+			expectVal: 0,
+		},
+	}
+
+	stdLoggr := logrus.StandardLogger()
+	ctx := context.WithValue(context.Background(), utils_test.TestingTContextKey, t)
+	ctx = ctxlogrus.ToContext(ctx, logrus.NewEntry(stdLoggr))
+
+	for nth, tm := range testMap {
+		mockOpaClienter := MockOpaClienter{
+			Loggr:        stdLoggr,
+			RegoRespJSON: tm.regoJSON,
+		}
+		auther := NewDefaultAuthorizer("bogus_unused_application_value",
+			WithOpaClienter(&mockOpaClienter),
+		)
+
+		actualVal, actualErr := auther.GetCspBySfdc(ctx, tm.sfdcID)
+		t.Logf("%d: %q: actualErr=%v, actualVal=%d", nth, tm.name, actualErr, actualVal)
+
+		if tm.expectErr && actualErr == nil {
+			t.Errorf("%d: %q: FAIL: expected err, but got no err", nth, tm.name)
+		} else if !tm.expectErr && actualErr != nil {
+			t.Errorf("%d: %q: FAIL: got unexpected err=%s", nth, tm.name, actualErr)
+		}
+
+		if actualVal != tm.expectVal {
+			t.Errorf("%d: %q: FAIL: expectVal=%d actualVal=%d",
+				nth, tm.name, tm.expectVal, actualVal)
+		}
+	}
+}
+
+func TestGetSandboxesForParentMockOpaClient(t *testing.T) {
+	testMap := []struct {
+		name      string
+		parentID  string
+		regoJSON  string
+		expectErr bool
+		expectVal []int64
+	}{
+		{
+			name:      "parent with sandboxes",
+			parentID:  "100",
+			regoJSON:  `{"result": [200, 201]}`,
+			expectErr: false,
+			expectVal: []int64{200, 201},
+		},
+		{
+			name:      "parent with no sandboxes returns nil",
+			parentID:  "999",
+			regoJSON:  `{"result": null}`,
+			expectErr: false,
+			expectVal: nil,
+		},
+		{
+			name:      "empty result returns nil",
+			parentID:  "100",
+			regoJSON:  `{}`,
+			expectErr: false,
+			expectVal: nil,
+		},
+		{
+			name:      "invalid json returns error",
+			parentID:  "100",
+			regoJSON:  `[null]`,
+			expectErr: true,
+			expectVal: nil,
+		},
+	}
+
+	stdLoggr := logrus.StandardLogger()
+	ctx := context.WithValue(context.Background(), utils_test.TestingTContextKey, t)
+	ctx = ctxlogrus.ToContext(ctx, logrus.NewEntry(stdLoggr))
+
+	for nth, tm := range testMap {
+		mockOpaClienter := MockOpaClienter{
+			Loggr:        stdLoggr,
+			RegoRespJSON: tm.regoJSON,
+		}
+		auther := NewDefaultAuthorizer("bogus_unused_application_value",
+			WithOpaClienter(&mockOpaClienter),
+		)
+
+		actualVal, actualErr := auther.GetSandboxesForParent(ctx, tm.parentID)
+		t.Logf("%d: %q: actualErr=%v, actualVal=%v", nth, tm.name, actualErr, actualVal)
+
+		if tm.expectErr && actualErr == nil {
+			t.Errorf("%d: %q: FAIL: expected err, but got no err", nth, tm.name)
+		} else if !tm.expectErr && actualErr != nil {
+			t.Errorf("%d: %q: FAIL: got unexpected err=%s", nth, tm.name, actualErr)
+		}
+
+		if !reflect.DeepEqual(actualVal, tm.expectVal) {
+			t.Errorf("%d: %q: FAIL: expectVal=%v actualVal=%v",
+				nth, tm.name, tm.expectVal, actualVal)
+		}
+	}
+}

--- a/grpc_opa/account_metadata_test.go
+++ b/grpc_opa/account_metadata_test.go
@@ -25,22 +25,22 @@ func TestGetAccountMetadataMockOpaClient(t *testing.T) {
 			regoJSON: `{
 				"result": {
 					"identity_id": "f0e1d2c3-b4a5-6789-0fed-cba987654321",
-					"csp_id": 200,
+					"csp_id": "200",
 					"sfdc_account_id": "",
 					"account_type": "sandbox",
 					"parent_account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-					"parent_csp_id": 100,
+					"parent_csp_id": "100",
 					"state": "active"
 				}
 			}`,
 			expectErr: false,
 			expectedVal: &AccountMetadataResult{
 				IdentityID:      "f0e1d2c3-b4a5-6789-0fed-cba987654321",
-				CspID:           200,
+				CspID:           "200",
 				SfdcAccountID:   "",
 				AccountType:     "sandbox",
 				ParentAccountID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-				ParentCspID:     100,
+				ParentCspID:     "100",
 				State:           "active",
 			},
 		},
@@ -50,22 +50,22 @@ func TestGetAccountMetadataMockOpaClient(t *testing.T) {
 			regoJSON: `{
 				"result": {
 					"identity_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-					"csp_id": 100,
+					"csp_id": "100",
 					"sfdc_account_id": "001ABC000XYZ123",
 					"account_type": "regular",
 					"parent_account_id": "",
-					"parent_csp_id": 0,
+					"parent_csp_id": "",
 					"state": "active"
 				}
 			}`,
 			expectErr: false,
 			expectedVal: &AccountMetadataResult{
 				IdentityID:      "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-				CspID:           100,
+				CspID:           "100",
 				SfdcAccountID:   "001ABC000XYZ123",
 				AccountType:     "regular",
 				ParentAccountID: "",
-				ParentCspID:     0,
+				ParentCspID:     "",
 				State:           "active",
 			},
 		},
@@ -131,35 +131,35 @@ func TestGetParentCspIdMockOpaClient(t *testing.T) {
 		accountID string
 		regoJSON  string
 		expectErr bool
-		expectVal int64
+		expectVal string
 	}{
 		{
 			name:      "sandbox returns parent id",
 			accountID: "200",
-			regoJSON:  `{"result": 100}`,
+			regoJSON:  `{"result": "100"}`,
 			expectErr: false,
-			expectVal: 100,
+			expectVal: "100",
 		},
 		{
-			name:      "non-sandbox returns zero",
+			name:      "non-sandbox returns empty",
 			accountID: "100",
 			regoJSON:  `{"result": null}`,
 			expectErr: false,
-			expectVal: 0,
+			expectVal: "",
 		},
 		{
-			name:      "account not found returns zero",
+			name:      "account not found returns empty",
 			accountID: "999",
 			regoJSON:  `{}`,
 			expectErr: false,
-			expectVal: 0,
+			expectVal: "",
 		},
 		{
 			name:      "invalid json returns error",
 			accountID: "200",
 			regoJSON:  `[null]`,
 			expectErr: true,
-			expectVal: 0,
+			expectVal: "",
 		},
 	}
 
@@ -177,7 +177,7 @@ func TestGetParentCspIdMockOpaClient(t *testing.T) {
 		)
 
 		actualVal, actualErr := auther.GetParentCspId(ctx, tm.accountID)
-		t.Logf("%d: %q: actualErr=%v, actualVal=%d", nth, tm.name, actualErr, actualVal)
+		t.Logf("%d: %q: actualErr=%v, actualVal=%s", nth, tm.name, actualErr, actualVal)
 
 		if tm.expectErr && actualErr == nil {
 			t.Errorf("%d: %q: FAIL: expected err, but got no err", nth, tm.name)
@@ -186,7 +186,7 @@ func TestGetParentCspIdMockOpaClient(t *testing.T) {
 		}
 
 		if actualVal != tm.expectVal {
-			t.Errorf("%d: %q: FAIL: expectVal=%d actualVal=%d",
+			t.Errorf("%d: %q: FAIL: expectVal=%s actualVal=%s",
 				nth, tm.name, tm.expectVal, actualVal)
 		}
 	}
@@ -198,28 +198,28 @@ func TestGetCspBySfdcMockOpaClient(t *testing.T) {
 		sfdcID    string
 		regoJSON  string
 		expectErr bool
-		expectVal int64
+		expectVal string
 	}{
 		{
 			name:      "valid sfdc returns csp id",
 			sfdcID:    "001ABC000XYZ123",
-			regoJSON:  `{"result": 100}`,
+			regoJSON:  `{"result": "100"}`,
 			expectErr: false,
-			expectVal: 100,
+			expectVal: "100",
 		},
 		{
-			name:      "unknown sfdc returns zero",
+			name:      "unknown sfdc returns empty",
 			sfdcID:    "001UNKNOWN",
 			regoJSON:  `{"result": null}`,
 			expectErr: false,
-			expectVal: 0,
+			expectVal: "",
 		},
 		{
 			name:      "invalid json returns error",
 			sfdcID:    "001ABC",
 			regoJSON:  `[null]`,
 			expectErr: true,
-			expectVal: 0,
+			expectVal: "",
 		},
 	}
 
@@ -237,7 +237,7 @@ func TestGetCspBySfdcMockOpaClient(t *testing.T) {
 		)
 
 		actualVal, actualErr := auther.GetCspBySfdc(ctx, tm.sfdcID)
-		t.Logf("%d: %q: actualErr=%v, actualVal=%d", nth, tm.name, actualErr, actualVal)
+		t.Logf("%d: %q: actualErr=%v, actualVal=%s", nth, tm.name, actualErr, actualVal)
 
 		if tm.expectErr && actualErr == nil {
 			t.Errorf("%d: %q: FAIL: expected err, but got no err", nth, tm.name)
@@ -246,7 +246,7 @@ func TestGetCspBySfdcMockOpaClient(t *testing.T) {
 		}
 
 		if actualVal != tm.expectVal {
-			t.Errorf("%d: %q: FAIL: expectVal=%d actualVal=%d",
+			t.Errorf("%d: %q: FAIL: expectVal=%s actualVal=%s",
 				nth, tm.name, tm.expectVal, actualVal)
 		}
 	}
@@ -258,14 +258,14 @@ func TestGetSandboxesForParentMockOpaClient(t *testing.T) {
 		parentID  string
 		regoJSON  string
 		expectErr bool
-		expectVal []int64
+		expectVal []string
 	}{
 		{
 			name:      "parent with sandboxes",
 			parentID:  "100",
-			regoJSON:  `{"result": [200, 201]}`,
+			regoJSON:  `{"result": ["200", "201"]}`,
 			expectErr: false,
-			expectVal: []int64{200, 201},
+			expectVal: []string{"200", "201"},
 		},
 		{
 			name:      "parent with no sandboxes returns nil",

--- a/grpc_opa/authorizer.go
+++ b/grpc_opa/authorizer.go
@@ -127,13 +127,19 @@ func (a AuthorizeFn) Evaluate(ctx context.Context, fullMethod string, grpcReq in
 
 func NewDefaultAuthorizer(application string, opts ...Option) *DefaultAuthorizer {
 	cfg := &Config{
-		address:                   opa_client.DefaultAddress,
-		decisionInputHandler:      defDecisionInputer,
-		claimsVerifier:            UnverifiedClaimFromBearers,
-		acctEntitlementsApi:       DefaultAcctEntitlementsApiPath,
-		currUserCompartmentsApi:   DefaultCurrentUserCompartmentsPath,
-		filterCompartmentPermsApi: DefaultFilterCompartmentPermissionsApiPath,
-		filterCompartmentFeatsApi: DefaultFilterCompartmentFeaturesApiPath,
+		address:                        opa_client.DefaultAddress,
+		decisionInputHandler:           defDecisionInputer,
+		claimsVerifier:                 UnverifiedClaimFromBearers,
+		acctEntitlementsApi:            DefaultAcctEntitlementsApiPath,
+		currUserCompartmentsApi:        DefaultCurrentUserCompartmentsPath,
+		filterCompartmentPermsApi:      DefaultFilterCompartmentPermissionsApiPath,
+		filterCompartmentFeatsApi:      DefaultFilterCompartmentFeaturesApiPath,
+		accountMetadataApi:             DefaultAccountMetadataApiPath,
+		parentCspIdApi:                 DefaultParentCspIdApiPath,
+		cspBySfdcApi:                   DefaultCspBySfdcApiPath,
+		sandboxesForParentApi:          DefaultSandboxesForParentApiPath,
+		acctEntitlementsFilteredApi:    DefaultAcctEntitlementsFilteredApiPath,
+		accountMetadataBySfdcApi:       DefaultAccountMetadataBySfdcApiPath,
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -147,31 +153,43 @@ func NewDefaultAuthorizer(application string, opts ...Option) *DefaultAuthorizer
 	}
 
 	a := DefaultAuthorizer{
-		clienter:                  clienter,
-		opaEvaluator:              cfg.opaEvaluator,
-		application:               application,
-		decisionInputHandler:      cfg.decisionInputHandler,
-		claimsVerifier:            cfg.claimsVerifier,
-		entitledServices:          cfg.entitledServices,
-		acctEntitlementsApi:       cfg.acctEntitlementsApi,
-		currUserCompartmentsApi:   cfg.currUserCompartmentsApi,
-		filterCompartmentPermsApi: cfg.filterCompartmentPermsApi,
-		filterCompartmentFeatsApi: cfg.filterCompartmentFeatsApi,
+		clienter:                       clienter,
+		opaEvaluator:                   cfg.opaEvaluator,
+		application:                    application,
+		decisionInputHandler:           cfg.decisionInputHandler,
+		claimsVerifier:                 cfg.claimsVerifier,
+		entitledServices:               cfg.entitledServices,
+		acctEntitlementsApi:            cfg.acctEntitlementsApi,
+		currUserCompartmentsApi:        cfg.currUserCompartmentsApi,
+		filterCompartmentPermsApi:      cfg.filterCompartmentPermsApi,
+		filterCompartmentFeatsApi:      cfg.filterCompartmentFeatsApi,
+		accountMetadataApi:             cfg.accountMetadataApi,
+		parentCspIdApi:                 cfg.parentCspIdApi,
+		cspBySfdcApi:                   cfg.cspBySfdcApi,
+		sandboxesForParentApi:          cfg.sandboxesForParentApi,
+		acctEntitlementsFilteredApi:    cfg.acctEntitlementsFilteredApi,
+		accountMetadataBySfdcApi:       cfg.accountMetadataBySfdcApi,
 	}
 	return &a
 }
 
 type DefaultAuthorizer struct {
-	application               string
-	clienter                  opa_client.Clienter
-	opaEvaluator              OpaEvaluator
-	decisionInputHandler      DecisionInputHandler
-	claimsVerifier            ClaimsVerifier
-	entitledServices          []string
-	acctEntitlementsApi       string
-	currUserCompartmentsApi   string
-	filterCompartmentPermsApi string
-	filterCompartmentFeatsApi string
+	application                    string
+	clienter                       opa_client.Clienter
+	opaEvaluator                   OpaEvaluator
+	decisionInputHandler           DecisionInputHandler
+	claimsVerifier                 ClaimsVerifier
+	entitledServices               []string
+	acctEntitlementsApi            string
+	currUserCompartmentsApi        string
+	filterCompartmentPermsApi      string
+	filterCompartmentFeatsApi      string
+	accountMetadataApi             string
+	parentCspIdApi                 string
+	cspBySfdcApi                   string
+	sandboxesForParentApi          string
+	acctEntitlementsFilteredApi    string
+	accountMetadataBySfdcApi       string
 }
 
 type Config struct {
@@ -179,16 +197,22 @@ type Config struct {
 	// address to opa
 	address string
 
-	clienter                  opa_client.Clienter
-	opaEvaluator              OpaEvaluator
-	authorizer                []Authorizer
-	decisionInputHandler      DecisionInputHandler
-	claimsVerifier            ClaimsVerifier
-	entitledServices          []string
-	acctEntitlementsApi       string
-	currUserCompartmentsApi   string
-	filterCompartmentPermsApi string
-	filterCompartmentFeatsApi string
+	clienter                       opa_client.Clienter
+	opaEvaluator                   OpaEvaluator
+	authorizer                     []Authorizer
+	decisionInputHandler           DecisionInputHandler
+	claimsVerifier                 ClaimsVerifier
+	entitledServices               []string
+	acctEntitlementsApi            string
+	currUserCompartmentsApi        string
+	filterCompartmentPermsApi      string
+	filterCompartmentFeatsApi      string
+	accountMetadataApi             string
+	parentCspIdApi                 string
+	cspBySfdcApi                   string
+	sandboxesForParentApi          string
+	acctEntitlementsFilteredApi    string
+	accountMetadataBySfdcApi       string
 }
 
 type ClaimsVerifier func([]string, []string) (string, []error)

--- a/grpc_opa/options.go
+++ b/grpc_opa/options.go
@@ -76,49 +76,63 @@ func WithEntitledServices(entitledServices ...string) Option {
 // WithAcctEntitlementsApiPath overrides default AcctEntitlementsApiPath
 func WithAcctEntitlementsApiPath(acctEntitlementsApi string) Option {
 	return func(c *Config) {
-		c.acctEntitlementsApi = acctEntitlementsApi
+		if acctEntitlementsApi != "" {
+			c.acctEntitlementsApi = acctEntitlementsApi
+		}
 	}
 }
 
 // WithFilterComparmentPermissionsApiPath overrides default CurrentUserCompartmentsApiPath
 func WithFilterComparmentPermissionsApiPath(filterCompartmentPermsApi string) Option {
 	return func(c *Config) {
-		c.filterCompartmentPermsApi = filterCompartmentPermsApi
+		if filterCompartmentPermsApi != "" {
+			c.filterCompartmentPermsApi = filterCompartmentPermsApi
+		}
 	}
 }
 
 // WithFilterComparmentFeaturesApiPath overrides default CurrentUserCompartmentsApiPath
 func WithFilterComparmentFeaturesApiPath(filterCompartmentFeatsApi string) Option {
 	return func(c *Config) {
-		c.filterCompartmentFeatsApi = filterCompartmentFeatsApi
+		if filterCompartmentFeatsApi != "" {
+			c.filterCompartmentFeatsApi = filterCompartmentFeatsApi
+		}
 	}
 }
 
 // WithAccountMetadataApiPath overrides default AccountMetadataApiPath
 func WithAccountMetadataApiPath(accountMetadataApi string) Option {
 	return func(c *Config) {
-		c.accountMetadataApi = accountMetadataApi
+		if accountMetadataApi != "" {
+			c.accountMetadataApi = accountMetadataApi
+		}
 	}
 }
 
 // WithParentCspIdApiPath overrides default ParentCspIdApiPath
 func WithParentCspIdApiPath(parentCspIdApi string) Option {
 	return func(c *Config) {
-		c.parentCspIdApi = parentCspIdApi
+		if parentCspIdApi != "" {
+			c.parentCspIdApi = parentCspIdApi
+		}
 	}
 }
 
 // WithCspBySfdcApiPath overrides default CspBySfdcApiPath
 func WithCspBySfdcApiPath(cspBySfdcApi string) Option {
 	return func(c *Config) {
-		c.cspBySfdcApi = cspBySfdcApi
+		if cspBySfdcApi != "" {
+			c.cspBySfdcApi = cspBySfdcApi
+		}
 	}
 }
 
 // WithSandboxesForParentApiPath overrides default SandboxesForParentApiPath
 func WithSandboxesForParentApiPath(sandboxesForParentApi string) Option {
 	return func(c *Config) {
-		c.sandboxesForParentApi = sandboxesForParentApi
+		if sandboxesForParentApi != "" {
+			c.sandboxesForParentApi = sandboxesForParentApi
+		}
 	}
 }
 
@@ -141,4 +155,3 @@ func WithAccountMetadataBySfdcApiPath(path string) Option {
 		}
 	}
 }
-

--- a/grpc_opa/options.go
+++ b/grpc_opa/options.go
@@ -93,3 +93,52 @@ func WithFilterComparmentFeaturesApiPath(filterCompartmentFeatsApi string) Optio
 		c.filterCompartmentFeatsApi = filterCompartmentFeatsApi
 	}
 }
+
+// WithAccountMetadataApiPath overrides default AccountMetadataApiPath
+func WithAccountMetadataApiPath(accountMetadataApi string) Option {
+	return func(c *Config) {
+		c.accountMetadataApi = accountMetadataApi
+	}
+}
+
+// WithParentCspIdApiPath overrides default ParentCspIdApiPath
+func WithParentCspIdApiPath(parentCspIdApi string) Option {
+	return func(c *Config) {
+		c.parentCspIdApi = parentCspIdApi
+	}
+}
+
+// WithCspBySfdcApiPath overrides default CspBySfdcApiPath
+func WithCspBySfdcApiPath(cspBySfdcApi string) Option {
+	return func(c *Config) {
+		c.cspBySfdcApi = cspBySfdcApi
+	}
+}
+
+// WithSandboxesForParentApiPath overrides default SandboxesForParentApiPath
+func WithSandboxesForParentApiPath(sandboxesForParentApi string) Option {
+	return func(c *Config) {
+		c.sandboxesForParentApi = sandboxesForParentApi
+	}
+}
+
+// WithAcctEntitlementsFilteredApiPath overrides the default path for
+// acct_entitlements_filtered_api (used by GetAccountDetails and GetEnrichedAccountMetadata).
+func WithAcctEntitlementsFilteredApiPath(path string) Option {
+	return func(c *Config) {
+		if path != "" {
+			c.acctEntitlementsFilteredApi = path
+		}
+	}
+}
+
+// WithAccountMetadataBySfdcApiPath overrides the default path for
+// get_account_metadata_by_sfdc_api (used by GetAccountDetailsBySfdc).
+func WithAccountMetadataBySfdcApiPath(path string) Option {
+	return func(c *Config) {
+		if path != "" {
+			c.accountMetadataBySfdcApi = path
+		}
+	}
+}
+


### PR DESCRIPTION
## Description

This PR adds new methods to `DefaultAuthorizer` for querying account metadata from the OPA sidecar bundle. It introduces two sets of APIs:

1. **Legacy integer-ID methods** (`account_metadata.go`) — thin wrappers around existing OPA rules that return `int64` CSP IDs.
2. **Enriched/provider methods** (`account_metadata_provider.go`) — a new `AccountMetadataProvider` interface backed by richer OPA rules that return string CSP IDs and support sandbox-parent resolution transparently.

---

## Changes

### New Files

- **`grpc_opa/account_metadata.go`**
  Implements four methods on `DefaultAuthorizer` using direct OPA rule queries:
  - `GetAccountMetadata(ctx, accountID)` — fetches full account metadata by CSP account ID via `get_account_metadata_api`. Returns `*AccountMetadataResult` with `int64` CSP ID fields.
  - `GetParentCspId(ctx, sandboxCspID)` — resolves a sandbox account to its parent CSP ID (`int64`) via `get_parent_csp_id_api`.
  - `GetCspBySfdc(ctx, sfdcAccountID)` — resolves a SFDC account ID to a CSP ID (`int64`) via `get_csp_by_sfdc_api`.
  - `GetSandboxesForParent(ctx, parentCspID)` — returns all sandbox CSP IDs (`[]int64`) for a given parent via `get_sandboxes_for_parent_api`.

  New OPA path constants added:
  - `DefaultAccountMetadataApiPath`
  - `DefaultParentCspIdApiPath`
  - `DefaultCspBySfdcApiPath`
  - `DefaultSandboxesForParentApiPath`

- **`grpc_opa/account_metadata_provider.go`**
  Introduces the `AccountMetadataProvider` interface and its implementation on `DefaultAuthorizer` using enriched OPA rules that store CSP IDs as strings (matching the account-metadata-publisher format):
  - `GetEnrichedAccountMetadata(ctx, cspAccountID)` — queries `acct_entitlements_filtered_api` and returns `*AcctEntitlementEnrichedEntry` containing entitlements, account details, and a `ResolvedAccountID`. For STATE-1 sandbox accounts with `sandbox_parent_entitlement_enabled=true`, `ResolvedAccountID` is the parent's CSP ID.
  - `GetAccountDetails(ctx, cspAccountID)` — convenience wrapper over `GetEnrichedAccountMetadata` that extracts only `*AccountDetails`.
  - `GetAccountDetailsBySfdc(ctx, sfdcID)` — single-call SFDC-to-metadata lookup via `get_account_metadata_by_sfdc_api`.
  - `GetCspBySfdcID(ctx, sfdcID)` — resolves a SFDC account ID to a string CSP ID via `get_csp_by_sfdc_api`.

  New OPA path constants added:
  - `DefaultAcctEntitlementsFilteredApiPath`
  - `DefaultAccountMetadataBySfdcApiPath`

- **`grpc_opa/account_metadata_test.go`**
  Unit tests for the legacy integer-ID methods using `MockOpaClienter`:
  - `TestGetAccountMetadataMockOpaClient`
  - `TestGetParentCspIdMockOpaClient`
  - `TestGetCspBySfdcMockOpaClient`
  - `TestGetSandboxesForParentMockOpaClient`

- **`grpc_opa/account_metadata_provider_test.go`**
  Unit tests for the enriched provider methods using `MockOpaClienter`:
  - `TestGetEnrichedAccountMetadataMockOpaClient`
  - `TestGetAccountDetailsMockOpaClient`
  - `TestGetAccountDetailsBySfdcMockOpaClient`
  - `TestGetCspBySfdcIDMockOpaClient`

### Modified Files

- **`grpc_opa/authorizer.go`**
  Added six new fields to both `DefaultAuthorizer` and `Config` structs:
  - `accountMetadataApi`
  - `parentCspIdApi`
  - `cspBySfdcApi`
  - `sandboxesForParentApi`
  - `acctEntitlementsFilteredApi`
  - `accountMetadataBySfdcApi`

  `NewDefaultAuthorizer` initializes all new fields with their respective default OPA path constants.

- **`grpc_opa/options.go`**
  Added six new `Option` functions to allow callers to override the default OPA API paths:
  - `WithAccountMetadataApiPath`
  - `WithParentCspIdApiPath`
  - `WithCspBySfdcApiPath`
  - `WithSandboxesForParentApiPath`
  - `WithAcctEntitlementsFilteredApiPath`
  - `WithAccountMetadataBySfdcApiPath`

---

## Notes

- All new methods return `nil` result (not an error) when the requested account or SFDC ID is absent from the OPA bundle. Callers should treat a `nil` result as a cache miss and fall back to the Identity API if needed.
- `AccountDetails` uses `string` for all ID fields (`CspID`, `ParentCspID`) to match the OPA bundle format where IDs are stored as decimal strings by the account-metadata-publisher. This differs from `AccountMetadataResult` (legacy) which uses `int64`.
- Consumers should prefer `ResolvedAccountID` from `AcctEntitlementEnrichedEntry` for all downstream entitlement/license lookups to ensure transparent sandbox-to-parent redirection.